### PR TITLE
fix(release): 重設版本號為 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "bootstrap-sha": "61d4e4af1c07b4219f56ed311bf34f8af43984be",
+      "release-as": "0.1.0",
       "changelog-sections": [
         { "type": "feat", "section": "✨ 新功能" },
         { "type": "fix", "section": "🐛 錯誤修復" },


### PR DESCRIPTION
## Summary

- release-please 掃描歷史 commit 的 BREAKING CHANGE，自動跳版至 v1.0.0
- 刪除 v1.0.0 Release 與 tag
- 設定 `bootstrap-sha` 指向目前 main HEAD，讓工具只掃未來 commit
- 設定 `release-as: 0.1.0` 強制下一個 Release 從 0.1.0 開始
- 重設 `.release-please-manifest.json` 與 `package.json` 回 0.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)