### PR TITLE
docs(engineering): 同步 topic-020/topic-021 Action Items 完成狀態

### DIFF
--- a/docs/conventions/governance/team-composition.md
+++ b/docs/conventions/governance/team-composition.md
@@ -74,5 +74,6 @@ source_of_truth: false
 | T-017 | doc-viewer docs-governance 文件分類落差分析與改進建議 | 2026-06-13 | conventions | ✅ 完成（待回報 doc-viewer） |
 | T-018 | 文件治理：戰略面與工程技術面分類規劃 | 2026-06-13 | conventions | ✅ 完成 |
 | T-019 | 文件治理遷移報告：T-018 Phase 2-5 執行結果 | 2026-06-13 | conventions | ✅ 完成 |
+| T-020 | ArticleListTree Reactivity 根因調查（topic-021） | 2026-06-14 | engineering | 🔄 進行中（已排除 4 個假設，待分層 debug log） |
 | UX-001 | 表單設計規範 | 2026-02-15 | product | ✅ 完成 |
 | RETRO-001 | 流程回顧：一個需求變三個 Branch | 2026-02-15 | delivery | ✅ 完成 |

--- a/docs/engineering/discussions/T-020-articlelisttree-reactivity-investigation.md
+++ b/docs/engineering/discussions/T-020-articlelisttree-reactivity-investigation.md
@@ -1,0 +1,161 @@
+---
+title: "ArticleListTree Reactivity 根因調查（topic-021）"
+domain: engineering
+type: spec
+status: approved
+owner: tech-team
+updated: 2026-06-14
+source_of_truth: true
+---
+
+# 技術會議 T-020 — ArticleListTree 在完整 E2E 套件中無法顯示新偵測文章（topic-021 根因調查）
+
+> **日期**: 2026-06-14
+> **主持**: Sam（Tech Lead）
+> **參與**: Wei（Frontend）、Lin（Services）、Alex（UI/UX）
+> **背景**: topic-020 E2E 驗收時發現，`tests/e2e/writing-baseline.spec.ts` 第 6 個測試（切換文章自動儲存）在完整 7 項 serial 套件中執行時，新偵測到的第二篇文章「切換目標文章」始終不會出現在 `ArticleListTree`（`otherRow.waitFor` 於 15354ms 逾時），但單獨執行該測試可通過。詳見 [topic-021 PENDING](./topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md)。
+
+---
+
+## 任務清單
+
+| # | 任務 | 負責 | 狀態 |
+|---|------|------|------|
+| 1 | 彙整 codebase 既有事實，更新/修正 PENDING.md 假設 | Sam | ✅ 完成 |
+| 2 | 各角色提出根因假設並交互討論收斂 | Sam/Lin/Wei/Alex | ✅ 完成 |
+| 3 | 決定修復策略並排定後續行動項目 | Sam | ✅ 完成 |
+
+---
+
+## 已確認的技術事實（會議前彙整，修正 PENDING.md 部分假設）
+
+### 1. E2E 測試環境結構（修正 PENDING 的「多個 window.reload()」假設）
+
+- `tests/e2e/helpers/electron-fixture.ts`：`electronApp`／`testVaultPath` 為 **worker scope**，整個 spec 共用同一個 Electron App 實例與同一個 `window`（Page）；`window` fixture 每個 test 重新 `getAppWindow()`，但因為 App 只開一個主視窗，取得的是**同一個 Page 物件**（同一個 renderer JS context，Pinia store 不會重建）
+- **全 spec 只有一次 `window.reload()`**，發生在 `beforeEach` 中由 `configInitialized` 旗標保護，只在第一個測試執行時觸發；後續 6 個測試共用同一個已 reload 過的頁面
+- 每個 worker 使用全新的 `userDataPath`（`fs.mkdtempSync`），因此 `localStorage` 在 spec 開始時為空
+- **結論**：PENDING.md 待決策項目 1 中「Pinia store 在多個 `window.reload()`/測試間的 effect scope 被提前釋放」**不成立**——全程只有一個 store 實例、一次 reload，effect scope 不會被釋放重建
+
+### 2. 資料流與渲染鏈（完整版，補上 PENDING 未列出的中間層）
+
+```
+articleStore.articles (ref, push 後 1→2，已透過 debug log 確認事實)
+  └─ useArticleFilter(articles).filteredArticles  [Pinia store 層 computed]
+       依 filter.value.{status,category,tags} + debouncedSearchText（300ms debounce）過濾
+       └─ ArticleListTree.vue 內部「第二層」 filteredArticles  [元件層 computed]
+            依元件本地 searchText（與 store 的 filter.searchText 是「兩個不同的狀態」）再過濾一次
+            └─ seriesGroups  [元件層 computed]
+                 依 article.frontmatter.series 分組，無 series → "_standalone"（顯示為「📄 獨立文章」）
+                 └─ template v-show="!collapsedGroups.has(group.name)" 內 ArticleTreeItem
+```
+
+### 3. ArticleListTree.vue 本地狀態（`src/components/ArticleListTree.vue:154-161`）
+
+- `searchText = ref("")`：元件本地搜尋字串，**與 Pinia store 的 `filter.searchText` 是兩條獨立狀態**，互不同步
+- `groupBySeries = ref(true)`：**預設為 true**，且會在 `onMounted` 時被 `loadSettings()`（讀 `localStorage["article-list-settings"]`）覆寫
+- `collapsedGroups = ref(new Set<string>())`：初始為空集合；spec 開始時 localStorage 為空，所以 `loadSettings()` 不會填入任何值，且全程沒有測試呼叫 `toggleGroup`/`collapseAll`，故 `collapsedGroups` 應全程為空集合
+- 兩篇文章（主文章「寫作基線主文章」、新文章「切換目標文章」）皆無 `frontmatter.series`，理論上都會落在同一個 `"_standalone"` 群組
+
+### 4. fixtures 內容
+
+- `writing-baseline-main.md`：`title: 寫作基線主文章`、`date: 2026-06-13`、`draft: true`，無 `series`
+- `switch-target.md`：`title: 切換目標文章`、`pubDate: 2026-06-13`，無 `status`/`draft`/`series`
+
+### 5. 測試 1-5 對主文章編輯器的操作（full-suite 下 test 6 執行前已發生）
+
+1. Ctrl+B 包裹選取文字
+2. Ctrl+B 插入 `**bold text**`
+3. Ctrl+2 切換 `##` 標題（toggle）
+4. Ctrl+Shift+F 插入 `[^1]` 腳註引用與文末定義（已修復與 focus mode 衝突，Fix #4）
+5. Ctrl+S 手動儲存 + 磁碟內容/frontmatter 驗證
+
+### 6. useArticleFilter.ts（`src/composables/useArticleFilter.ts`，已讀全文）
+
+- `filteredArticles` 為純 `computed`，依賴 `articles.value` 與 `debouncedSearchText.value`
+- `debouncedSearchText` 透過 `watch(() => filter.value.searchText, ...)` + `setTimeout(300ms)` 更新；**全程沒有測試呼叫 `updateFilter`**，故 `filter.value.searchText` 應維持初始值 `""`，`debouncedSearchText` 也維持 `""`
+- `filter.value.status`/`category`/`tags` 全程維持 `DEFAULT_ARTICLE_FILTER`（`All`/`All`/`[]`），理論上不會過濾掉任何文章
+
+---
+
+## 討論記錄
+
+### 第一輪：各角色獨立提出假設
+
+**Sam**：「我看了一下整條鏈，我認為斷裂點不在 `seriesGroups`/`collapsedGroups` 的結構本身——這兩個 ref 全程沒被任何測試動過，結構性沒問題。比較值得懷疑的是 `ArticleListTree.vue` 本地的 `searchText`／`collapsedGroups`：如果 `onMounted` 的 `loadSettings()` 在 full-suite 下因為某種非同步時序，在文章 push 之後才把 `'_standalone'` 加入 `collapsedGroups`，`v-show=\"!collapsedGroups.has(group.name)\"` 就會把整個『📄 獨立文章』群組藏起來，新文章自然等不到 visible。」
+
+**Lin**：「我把 `reloadArticleFromDisk` 和 `FileWatchService` 完整看過了。`articles.value.push(article)` 在 Pinia 的 `ref([])` 下是有攔截的，會正常觸發 `filteredArticles` 重算，push vs spread 不是根因。但我比較在意 `FileWatchService.handleFileChange` 的 `recentEvents`／`ignoreNextChange`——這個去抖 map 沒把 `event` type 納入 key，如果 serial 套件前面測試對同一路徑的 `ignoreNextChange` 殘留命中，第 6 個測試新增檔案的 change 事件可能在 `handleFileChange` 第一關就被吃掉，根本不會送到 `handleFileChangeEvent`。所以我想先確認：**第 6 個測試在 full-suite 失敗時，`articles.value.length` 真的有變成 2 嗎？**」
+
+**Wei**：「我剛剛在元件裡翻了一下，方向跟 Sam 接近——懷疑 `collapsedGroups` 裡 `'_standalone'` 被意外加入。但我多想到一點：`treeContainerRef` 有 `tabindex=\"0\"` + `@keydown=\"handleKeydown\"`，測試 1-5 操作 CodeMirror 時的鍵盤事件會不會冒泡到這裡，誤觸發收合行為？我還沒看到 `handleKeydown` 完整實作，這是我想先確認的點。」
+
+**Alex**：「先說一個跟根因無關但值得記錄的設計債：元件本地 `searchText` 跟 store 的 `filter.searchText` 是兩條獨立狀態，使用者在側邊欄搜尋、切到文章管理頁面卻發現沒套用搜尋，會覺得體驗斷裂——這次先不卡這個。但如果根因真的是『某個 computed 在 full-suite 下沒重新觸發』，對應到真實使用情境就是『FileWatch 偵測到新檔案，但側邊欄不會自動出現』，這跟我們對『自動偵測』的承諾矛盾，是信任感問題，不只是 UI 小瑕疵。修復時建議順手加：新項目加入時自動展開所在群組＋短暫高亮提示。」
+
+### 第二輪：Sam（主持）裁決與收斂
+
+**Sam**：「我針對 Lin 的疑問核對了一下 topic-021 PENDING.md 的記錄——『`articleStore.articles.value` 在 push 後長度由 1→2』這條事實，**是在 topic-020 E2E 驗收期間、針對這次 full-suite 失敗案例本身**加 debug log 確認的，不是單跑時的結果。所以 Lin 的 `FileWatchService` debounce/`recentEvents` 假設可以先排除——資料確實送到 store 了，問題在更下游。」
+
+「再針對 Wei 的問題，我去重讀了 `ArticleListTree.vue` 的 `handleKeydown` 和 `loadSettings` 完整實作：
+
+```ts
+function handleKeydown(e: KeyboardEvent) {
+  if ((e.ctrlKey || e.metaKey) && e.key === "f") {
+    e.preventDefault()
+    searchInputRef.value?.focus()
+  }
+}
+
+function loadSettings() {
+  const saved = localStorage.getItem("article-list-settings")
+  if (saved) {
+    try {
+      const settings = JSON.parse(saved)
+      groupBySeries.value = settings.groupBySeries ?? true
+      ...
+```
+
+`handleKeydown` 只處理 Ctrl/Cmd+F 聚焦搜尋框，完全不會動 `collapsedGroups`——Wei 的『鍵盤事件冒泡誤觸發收合』假設不成立。`loadSettings()` 也是**完全同步**（`localStorage.getItem` + `JSON.parse`），不是非同步，而且這個 worker 的 `localStorage` 一開始就是空的（`userDataPath` 全新建立），`saved` 為 `null`，整個 `if (saved)` 區塊不會執行——`collapsedGroups` 在 `onMounted` 之後應該就是空集合，不會被『非同步寫入 _standalone』。我自己提的 `loadSettings` 時序假設，也不成立。」
+
+「所以**第一輪四個假設都被排除了**：不是 FileWatch debounce、不是 effect scope 釋放（會前已排除）、不是 `loadSettings` 時序、不是 `handleKeydown` 誤觸發。剩下能確定的只有：問題出在『`articles.value` 1→2』到『`seriesGroups`/`filteredArticles` 渲染出新的 `ArticleTreeItem`』這條鏈的**某個 computed 層**，但具體哪一層在 full-suite 下沒有正確重算，光靠讀程式碼已經無法再縮小範圍——這完全符合 PENDING.md 原本的判斷：『需要逐層加 log / 隔離測試，屬技術深挖』。我建議不要再猜測，直接做分層 debug log。」
+
+### 第三輪：收斂為具體行動
+
+**Wei**：「我同意。那我來設計分層 log：在 `useArticleFilter.ts` 的 `filteredArticles` computed 開頭印 `articles.value.length`；在 `ArticleListTree.vue` 的元件層 `filteredArticles` computed 印 `articleStore.filteredArticles.length` 與自己回傳的 `.length`；在 `seriesGroups` computed 印 `filteredArticles.value.length` 與每個 group 的 `name`/`articles.length`。三層都印，跑 full-suite，因為 `electron-fixture.ts` 本來就會把 renderer console 寫到 `test-results/renderer-console.log`，不需要額外設定。比對單跑 vs full-suite 的這三層 log，斷裂點會在某一層『上游印出 2 但下游印出 1』的地方現形。」
+
+**Sam**：「同意，這是低成本、高訊息量的下一步。Wei 你來做。完成條件：`test-results/renderer-console.log` 在 full-suite 執行第 6 個測試時，三層 log 都有輸出，且能明確指出哪一層的輸出長度沒有從 1 變成 2（或 group 數量不對）。找到斷裂層後，再開下一次技術會議或直接在同分支修復並解除 `test.fixme`。」
+
+**Lin**：「沒問題，我這邊認領一個小任務：順手檢查 `FileWatchService.recentEvents` 的 key 是否該納入 `event` type——雖然這次不是根因，但『去抖 map 沒區分事件類型』本身是個潛在 bug，值得在同分支一起清掉，不需要另開分支。」
+
+**Alex**：「我這邊先不佔用本次行動項目，等根因確定、進入修復階段時，我會補一版『新文章加入時自動展開群組 + 高亮提示』的互動規格，到時候再跟 Wei 對一下實作可行性。」
+
+---
+
+## 設計決策
+
+1. **排除假設**：本次會議排除了 topic-021 PENDING.md 與會中提出的全部假設——「多個 `window.reload()` 導致 effect scope 釋放」「FileWatch debounce/`recentEvents` 污染」「`loadSettings()` 非同步時序競態」「`handleKeydown` 鍵盤事件誤觸發 `collapsedGroups`」。已確認 `articles.value` 在 full-suite 失敗案例中確實 1→2，問題範圍收斂到 `useArticleFilter.filteredArticles` → `ArticleListTree` 元件層 `filteredArticles` → `seriesGroups` 這條 computed 鏈中的某一層。
+2. **修復策略**：本次不直接修復，先以**分層 debug log + `renderer-console.log` 比對**定位斷裂層，再決定修復方式（明確 bug 修復 vs 設計檢視）。
+3. **附帶任務**：`FileWatchService.recentEvents` 的去抖 key 未納入 `event` type，視為獨立技術債，於同一分支（後續修復 topic-021 時）一併處理，不另開分支。
+4. **UX 補強**（待根因修復後排入同分支或下個 Sprint）：新文章加入既有群組時，若該群組已收合應自動展開，並給予短暫高亮提示，呼應 FileWatch「自動偵測新檔案」的承諾。
+5. **本地 `searchText` 與 store `filter.searchText` 不同步**：列為獨立設計債，本次不處理，未來如需處理應排技術會議另議（不在本次 topic-021 範圍）。
+
+## 共識與分歧
+
+- **共識**：四個第一輪假設經程式碼核對後均不成立；下一步是分層 debug log，由 Wei 負責，Sam 訂完成條件；test 6 維持 `test.fixme` 直到根因確認修復；`FileWatchService.recentEvents` key 缺陷與本次根因一併在同分支處理。
+- **無分歧**：本次討論收斂順利，未進入正式表決。
+
+## ✅ Action Items
+
+| # | 行動項目 | 負責人 | 優先級 | 完成條件 | 狀態 |
+|---|---------|-------|-------|---------|------|
+| 1 | 在 `useArticleFilter.ts`/`ArticleListTree.vue` 三層 computed 加分層 debug log，跑 full-suite 並比對 `renderer-console.log` 找出斷裂層 | Wei | P1 | `test-results/renderer-console.log` 顯示三層輸出，且能明確指出哪一層在 full-suite 下未從 1→2（或 group 數量不對） | ⏳ 待開始 |
+| 2 | 檢查並修復 `FileWatchService.recentEvents` 去抖 key 未納入 `event` type 的問題 | Lin | P2 | `recentEvents` key 包含 `event` type，相關 unit test 通過 | ⏳ 待開始 |
+| 3 | 根據 #1 找到的斷裂層，提出並實作修復、解除 test 6 `test.fixme` | 技術團隊（待 #1 結果指派） | P0 | `writing-baseline.spec.ts` 測試 6 通過，`pnpm run test` 0 failures | ⏳ 待開始 |
+| 4 | 新文章加入時自動展開群組＋高亮提示的互動規格 | Alex | P3 | 規格文件交付 Wei，於 #3 修復同分支或下個 Sprint 實作 | ⏳ 待開始 |
+
+## 相關文件
+
+- [topic-021 PENDING](./topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md)
+- [topic-020 決議](./topic-020-2026-06-13-save-race-data-overwrite/decision.md)
+- `src/composables/useArticleFilter.ts`
+- `src/components/ArticleListTree.vue`
+- `src/services/FileWatchService.ts`
+- `tests/e2e/writing-baseline.spec.ts`
+

--- a/docs/engineering/discussions/T-020-articlelisttree-reactivity-investigation.md
+++ b/docs/engineering/discussions/T-020-articlelisttree-reactivity-investigation.md
@@ -145,10 +145,10 @@ function loadSettings() {
 
 | # | 行動項目 | 負責人 | 優先級 | 完成條件 | 狀態 |
 |---|---------|-------|-------|---------|------|
-| 1 | 在 `useArticleFilter.ts`/`ArticleListTree.vue` 三層 computed 加分層 debug log，跑 full-suite 並比對 `renderer-console.log` 找出斷裂層 | Wei | P1 | `test-results/renderer-console.log` 顯示三層輸出，且能明確指出哪一層在 full-suite 下未從 1→2（或 group 數量不對） | ⏳ 待開始 |
-| 2 | 檢查並修復 `FileWatchService.recentEvents` 去抖 key 未納入 `event` type 的問題 | Lin | P2 | `recentEvents` key 包含 `event` type，相關 unit test 通過 | ⏳ 待開始 |
-| 3 | 根據 #1 找到的斷裂層，提出並實作修復、解除 test 6 `test.fixme` | 技術團隊（待 #1 結果指派） | P0 | `writing-baseline.spec.ts` 測試 6 通過，`pnpm run test` 0 failures | ⏳ 待開始 |
-| 4 | 新文章加入時自動展開群組＋高亮提示的互動規格 | Alex | P3 | 規格文件交付 Wei，於 #3 修復同分支或下個 Sprint 實作 | ⏳ 待開始 |
+| 1 | 在 `useArticleFilter.ts`/`ArticleListTree.vue` 三層 computed 加分層 debug log，跑 full-suite 並比對 `renderer-console.log` 找出斷裂層 | Wei | P1 | `test-results/renderer-console.log` 顯示三層輸出，且能明確指出哪一層在 full-suite 下未從 1→2（或 group 數量不對） | ✅ 完成（三層輸出皆正確，~10ms 內更新，computed 鏈本身無斷裂） |
+| 2 | 檢查並修復 `FileWatchService.recentEvents` 去抖 key 未納入 `event` type 的問題 | Lin | P2 | `recentEvents` key 包含 `event` type，相關 unit test 通過 | ⏳ 待開始（移至 Backlog，與本次根因無關） |
+| 3 | 根據 #1 找到的斷裂層，提出並實作修復、解除 test 6 `test.fixme` | 技術團隊（待 #1 結果指派） | P0 | `writing-baseline.spec.ts` 測試 6 通過，`pnpm run test` 0 failures | ✅ 完成 — 根因實為 Fix #5（Ctrl+B 側邊欄收合誤觸發，commit `be570b4`）與 reactivity 無關，已移除 `.fixme`，[PR #40](https://github.com/EanLee/article-write/pull/40) |
+| 4 | 新文章加入時自動展開群組＋高亮提示的互動規格 | Alex | P3 | 規格文件交付 Wei，於 #3 修復同分支或下個 Sprint 實作 | ⏳ 待開始（topic-021 已解決，無阻塞，移至 Backlog 評估是否仍需要） |
 
 ## 相關文件
 

--- a/docs/engineering/discussions/topic-020-2026-06-13-save-race-data-overwrite/decision.md
+++ b/docs/engineering/discussions/topic-020-2026-06-13-save-race-data-overwrite/decision.md
@@ -39,10 +39,10 @@ source_of_truth: true
 
 ## 驗收標準（Alex 提出，全體同意）
 
-- [ ] 三種觸發路徑寫入磁碟前，內容與編輯器當前內容一致——各自有 E2E 覆蓋
-- [ ] frontmatter 欄位（date、draft 等）儲存後完整保留
-- [ ] UI 顯示「已儲存」時，磁碟內容與畫面 100% 一致
-- [ ] 既有 `tests/e2e/writing-baseline.spec.ts` 的 `test.fixme` 解除並通過
+- [x] 三種觸發路徑寫入磁碟前，內容與編輯器當前內容一致——各自有 E2E 覆蓋
+- [x] frontmatter 欄位（date、draft 等）儲存後完整保留
+- [x] UI 顯示「已儲存」時，磁碟內容與畫面 100% 一致
+- [x] 既有 `tests/e2e/writing-baseline.spec.ts` 的 `test.fixme` 解除並通過
 
 ## ✅ Action Items
 
@@ -52,14 +52,14 @@ source_of_truth: true
 | 2 | 儲存來源單一化實作（A 方案，含切換時儲存路徑） | Taylor／技術團隊 | P0 | 三路徑統一取編輯器即時內容，unit + E2E 通過，1.5~2 天 | ✅ 完成（`84ac097 fix(store): 編輯器內容即時同步 store，統一儲存來源（topic-020 方案 A）`） |
 | 3 | frontmatter 序列化欄位保留修復 | Taylor／技術團隊 | P0 | date/draft 等欄位儲存後不遺失，同分支 | ✅ 完成（`1712aab fix(service): frontmatter 欄位完整保留與 own-write 衝突豁免`） |
 | 4 | 寫入後驗證＋Sentry 事件 | Sam | P1 | 不一致時可在 Sentry 看到事件 | ⏳ 待開始：尚無 Sentry 整合 |
-| 5 | 解除 test.fixme 並補三路徑 E2E | 技術團隊 | P1 | 驗收標準四項全過 | 🔄 進行中：`writing-baseline.spec.ts` 測試 1-5、7 已通過；測試 6（切換文章自動儲存）仍 `test.fixme`，根因卡在 [topic-021](../topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md)（ArticleListTree 在 full-suite 下 reactivity 未更新） |
+| 5 | 解除 test.fixme 並補三路徑 E2E | 技術團隊 | P1 | 驗收標準四項全過 | ✅ 完成：`writing-baseline.spec.ts` 測試 1-7 全數通過。測試 6 根因（[topic-021](../topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md)）確認為 Fix #5 側邊欄收合誤觸發（非 reactivity 問題），已於 [PR #40](https://github.com/EanLee/article-write/pull/40) 移除 `.fixme` |
 | 6 | 已知問題清單揭露文案（安心語氣版） | Lisa＋Jordan | P2 | 措辭定稿並發布，今日內 | ⏳ 待開始 |
-| 7 | 第三天驗收，決定是否順延 Launch | Alex | P0 | 驗收標準四項全過或宣布順延 | ⏳ 待開始：待 #5 解除 fixme（即 topic-021 解決）後方可進行驗收標準四項全過的判定 |
+| 7 | 第三天驗收，決定是否順延 Launch | Alex | P0 | 驗收標準四項全過或宣布順延 | 🔄 進行中：#5 已解除阻塞（驗收標準四項全過），可進行驗收判定 |
 
-> **狀態同步說明（2026-06-14）**：#2、#3 已於 `fix/save-single-source-of-truth` 分支完成並合併 `develop`，
+> **狀態同步說明（2026-06-14）**：#2、#3、#5 已完成並合併（或待合併）`develop`，
 > 詳見 [topic-020 E2E 驗收期間修復報告](../../../quality/assessments/fix-bug/2026-06-13-topic-020-e2e-acceptance-fixes.md)。
 > 該分支同時發現並修復 4 個額外的快捷鍵衝突問題（Fix #1/#4/#5）。
-> 目前唯一阻塞 #5/#7 完成的項目是 topic-021 的根因調查，建議排程技術會議。
+> [topic-021](../topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md) 根因已確認並解決（同 Fix #5），#5/#7 解除阻塞。
 
 ## 關聯文件
 

--- a/docs/engineering/discussions/topic-020-2026-06-13-save-race-data-overwrite/decision.md
+++ b/docs/engineering/discussions/topic-020-2026-06-13-save-race-data-overwrite/decision.md
@@ -4,7 +4,7 @@ domain: engineering
 type: rpd
 status: approved
 owner: roundtable-discussions
-updated: 2026-06-13
+updated: 2026-06-14
 source_of_truth: true
 ---
 
@@ -48,13 +48,18 @@ source_of_truth: true
 
 | # | 行動項目 | 負責人 | 優先級 | 完成條件 | 狀態 |
 |---|---------|-------|-------|---------|------|
-| 1 | 過渡防護：寫入前 mtime/hash 比對＋衝突彈窗（含 E2E） | Sam | P0 | 半天內上線，衝突時彈窗詢問、不覆寫 | ⏳ 待開始 |
-| 2 | 儲存來源單一化實作（A 方案，含切換時儲存路徑） | Taylor／技術團隊 | P0 | 三路徑統一取編輯器即時內容，unit + E2E 通過，1.5~2 天 | ⏳ 待開始 |
-| 3 | frontmatter 序列化欄位保留修復 | Taylor／技術團隊 | P0 | date/draft 等欄位儲存後不遺失，同分支 | ⏳ 待開始 |
-| 4 | 寫入後驗證＋Sentry 事件 | Sam | P1 | 不一致時可在 Sentry 看到事件 | ⏳ 待開始 |
-| 5 | 解除 test.fixme 並補三路徑 E2E | 技術團隊 | P1 | 驗收標準四項全過 | ⏳ 待開始 |
+| 1 | 過渡防護：寫入前 mtime/hash 比對＋衝突彈窗（含 E2E） | Sam | P0 | 半天內上線，衝突時彈窗詢問、不覆寫 | 🔄 進行中：`BackupService.detectConflict()` 已實作 mtime 比對，衝突時以 `notify.warning` 提示「重新載入」；尚缺 hash 比對與正式彈窗（目前為 toast） |
+| 2 | 儲存來源單一化實作（A 方案，含切換時儲存路徑） | Taylor／技術團隊 | P0 | 三路徑統一取編輯器即時內容，unit + E2E 通過，1.5~2 天 | ✅ 完成（`84ac097 fix(store): 編輯器內容即時同步 store，統一儲存來源（topic-020 方案 A）`） |
+| 3 | frontmatter 序列化欄位保留修復 | Taylor／技術團隊 | P0 | date/draft 等欄位儲存後不遺失，同分支 | ✅ 完成（`1712aab fix(service): frontmatter 欄位完整保留與 own-write 衝突豁免`） |
+| 4 | 寫入後驗證＋Sentry 事件 | Sam | P1 | 不一致時可在 Sentry 看到事件 | ⏳ 待開始：尚無 Sentry 整合 |
+| 5 | 解除 test.fixme 並補三路徑 E2E | 技術團隊 | P1 | 驗收標準四項全過 | 🔄 進行中：`writing-baseline.spec.ts` 測試 1-5、7 已通過；測試 6（切換文章自動儲存）仍 `test.fixme`，根因卡在 [topic-021](../topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md)（ArticleListTree 在 full-suite 下 reactivity 未更新） |
 | 6 | 已知問題清單揭露文案（安心語氣版） | Lisa＋Jordan | P2 | 措辭定稿並發布，今日內 | ⏳ 待開始 |
-| 7 | 第三天驗收，決定是否順延 Launch | Alex | P0 | 驗收標準四項全過或宣布順延 | ⏳ 待開始 |
+| 7 | 第三天驗收，決定是否順延 Launch | Alex | P0 | 驗收標準四項全過或宣布順延 | ⏳ 待開始：待 #5 解除 fixme（即 topic-021 解決）後方可進行驗收標準四項全過的判定 |
+
+> **狀態同步說明（2026-06-14）**：#2、#3 已於 `fix/save-single-source-of-truth` 分支完成並合併 `develop`，
+> 詳見 [topic-020 E2E 驗收期間修復報告](../../../quality/assessments/fix-bug/2026-06-13-topic-020-e2e-acceptance-fixes.md)。
+> 該分支同時發現並修復 4 個額外的快捷鍵衝突問題（Fix #1/#4/#5）。
+> 目前唯一阻塞 #5/#7 完成的項目是 topic-021 的根因調查，建議排程技術會議。
 
 ## 關聯文件
 

--- a/docs/engineering/discussions/topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md
+++ b/docs/engineering/discussions/topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md
@@ -4,7 +4,7 @@ domain: engineering
 type: rpd
 status: pending
 owner: roundtable-discussions
-updated: 2026-06-13
+updated: 2026-06-14
 source_of_truth: true
 ---
 
@@ -36,6 +36,20 @@ source_of_truth: true
 1. **根因調查方向**：是否為 `computed` 快取在 full-suite 長時間執行下未正確標記 dirty？或 Pinia store 在多個 `window.reload()`/測試間的 effect scope 被提前釋放？
 2. **修復策略**：根因確定後，是技術層自行修復（明確 bug）還是需重新檢視 `useArticleFilter` 的設計（可能涉及「當初為何這樣設計」）？
 3. **test 6/7 暫時狀態**：目前 test 6 已標記 `test.fixme` 並附註本文件連結；test 7（大綱面板）在 test 6 fixme 後因不再切換文章、留在主文章上，可正常通過——是否接受此暫時狀態直到根因修復？
+
+## T-020 技術會議結果（2026-06-14）
+
+已召開技術會議 [T-020](../T-020-articlelisttree-reactivity-investigation.md)，結論如下：
+
+- **已排除的假設**：
+  - ❌「多個 `window.reload()`/effect scope 被提前釋放」——全 spec 共用一個 Electron App + window，全程只有一次 `window.reload()`（test 1 的 beforeEach），Pinia store 不會重建
+  - ❌「`FileWatchService.recentEvents`/`ignoreNextChange` debounce 污染導致 change 事件未送達」——`articleStore.articles.value` 1→2 是在 full-suite 失敗案例中確認的事實，資料確實送到 store
+  - ❌「`ArticleListTree.vue` 的 `loadSettings()` 非同步時序競態使 `collapsedGroups` 收合 `_standalone`」——`loadSettings()` 為同步函式，且 worker 的 `localStorage` 初始為空，`collapsedGroups` 不會被填入
+  - ❌「`treeContainerRef` 的 `handleKeydown` 被冒泡鍵盤事件誤觸發收合」——`handleKeydown` 只處理 Ctrl/Cmd+F 聚焦搜尋框，不會動 `collapsedGroups`
+- **範圍收斂**：問題確定出在 `useArticleFilter.filteredArticles`（store 層）→ `ArticleListTree.vue` 元件層 `filteredArticles` → `seriesGroups` 這條 computed 鏈中的某一層，在 full-suite 下未正確重新計算或渲染，但純讀程式碼已無法再縮小範圍
+- **下一步**：分層 debug log + `renderer-console.log` 比對（T-020 Action Item #1，負責人 Wei，P1）
+- **附帶發現**：`FileWatchService.recentEvents` 去抖 key 未納入 `event` type，視為獨立技術債，於同分支一併處理（T-020 Action Item #2，負責人 Lin，P2）
+- **暫時狀態**：test 6 維持 `test.fixme`，待 T-020 Action Item #1 找出斷裂層後再排修復（T-020 Action Item #3）
 
 ## 建議的討論層次
 

--- a/docs/engineering/discussions/topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md
+++ b/docs/engineering/discussions/topic-021-2026-06-13-articlelisttree-reactivity/PENDING.md
@@ -1,8 +1,8 @@
 ---
-title: "ArticleListTree 在完整 E2E 套件中無法顯示新偵測文章（待排程）"
+title: "ArticleListTree 在完整 E2E 套件中無法顯示新偵測文章（已解決）"
 domain: engineering
 type: rpd
-status: pending
+status: approved
 owner: roundtable-discussions
 updated: 2026-06-14
 source_of_truth: true
@@ -10,10 +10,10 @@ source_of_truth: true
 
 # topic-021｜ArticleListTree 在完整 E2E 套件中無法顯示新偵測文章
 
-**日期**: 2026-06-13（待排程）
-**狀態**: ⚠️ 待技術會議排查
+**日期**: 2026-06-13
+**狀態**: ✅ 已解決（2026-06-14，[PR #40](https://github.com/EanLee/article-write/pull/40)）
 **發起人**: 技術團隊（topic-020 E2E 驗收時發現）
-**討論層次**: 技術會議 — 根因未定位的 reactivity 問題，需技術層深入調查後再決定是否升級
+**討論層次**: 技術會議 — 根因已定位，非 reactivity 問題，無需升級圓桌
 
 ## 背景與情境
 
@@ -47,19 +47,40 @@ source_of_truth: true
   - ❌「`ArticleListTree.vue` 的 `loadSettings()` 非同步時序競態使 `collapsedGroups` 收合 `_standalone`」——`loadSettings()` 為同步函式，且 worker 的 `localStorage` 初始為空，`collapsedGroups` 不會被填入
   - ❌「`treeContainerRef` 的 `handleKeydown` 被冒泡鍵盤事件誤觸發收合」——`handleKeydown` 只處理 Ctrl/Cmd+F 聚焦搜尋框，不會動 `collapsedGroups`
 - **範圍收斂**：問題確定出在 `useArticleFilter.filteredArticles`（store 層）→ `ArticleListTree.vue` 元件層 `filteredArticles` → `seriesGroups` 這條 computed 鏈中的某一層，在 full-suite 下未正確重新計算或渲染，但純讀程式碼已無法再縮小範圍
-- **下一步**：分層 debug log + `renderer-console.log` 比對（T-020 Action Item #1，負責人 Wei，P1）
-- **附帶發現**：`FileWatchService.recentEvents` 去抖 key 未納入 `event` type，視為獨立技術債，於同分支一併處理（T-020 Action Item #2，負責人 Lin，P2）
-- **暫時狀態**：test 6 維持 `test.fixme`，待 T-020 Action Item #1 找出斷裂層後再排修復（T-020 Action Item #3）
+- **下一步**：分層 debug log + `renderer-console.log` 比對（T-020 Action Item #1，負責人 Wei，P1）✅ 已完成，見下方「根因確認與解決」
+- **附帶發現**：`FileWatchService.recentEvents` 去抖 key 未納入 `event` type，視為獨立技術債，於同分支一併處理（T-020 Action Item #2，負責人 Lin，P2）— 仍為 Backlog，未在本次範圍處理
+- **暫時狀態**：test 6 維持 `test.fixme`，待 T-020 Action Item #1 找出斷裂層後再排修復（T-020 Action Item #3）✅ 已完成，已移除 `.fixme`
 
-## 建議的討論層次
+## 根因確認與解決（2026-06-14）
 
-| 議題 | 建議層次 | 原因 |
-|------|----------|------|
-| Reactivity 斷裂根因調查 | 技術會議 | 需要逐層加 log / 隔離測試，屬技術深挖 |
-| 若根因為架構設計問題（如 effect scope） | 視調查結果可能升級圓桌 | 「當初為何這樣設計」 |
+依 T-020 Action Item #1，在 `useArticleFilter.filteredArticles` → `ArticleListTree.filteredArticles` → `seriesGroups` 各層加入分層 debug log，重新執行 full-suite 並比對 `renderer-console.log`：
+
+```
+reloadArticleFromDisk push new article, articles.length= 2
+  → useArticleFilter.filteredArticles recompute, articles.length= 2
+  → ArticleListTree.filteredArticles recompute, result.length= 2
+  → ArticleListTree.seriesGroups recompute, result=[{"name":"_standalone","count":2}]
+```
+
+**結論：computed 鏈完全正常，~10ms 內即時更新，本問題從來不是 reactivity 斷裂。**
+
+真正逾時原因與 `docs/quality/assessments/fix-bug/2026-06-13-topic-020-e2e-acceptance-fixes.md` 的 **Fix #5（Ctrl+B 編輯器粗體誤觸發側邊欄收合，commit `be570b4`）同一根因**：
+
+```
+測試 1 按下 Ctrl+B → CodeMirror Mod-b 回傳 true → event.preventDefault()
+  → 事件冒泡至 App.vue handleGlobalKeydown
+  → [be570b4 修復前] 未檢查 e.defaultPrevented → toggleSidebar() → sidebarCollapsed=true
+  → 整個側邊欄（含 ArticleListTree）持續收合至測試 6 執行
+  → seriesGroups 資料正確，但 DOM 被收合隱藏 → otherRow.waitFor 逾時（表面現象）
+```
+
+`be570b4` 已於標記 test 6 `test.fixme` 的 commit（`2f9cac2`）之後 10 分鐘合併進 `develop`，但當時驗證未重新 `pnpm run build`，導致「測試 6 與 Fix #4/#5 無關」為誤判。
+
+**處理結果**：未變更 production code（Fix #5 已存在），移除測試 6 的 `.fixme` 與過時註解。`pnpm run test` 628 passed | 1 skipped；E2E 全套件重跑 2 次皆 7 passed（含測試 6）。詳見追加修復報告與 [PR #40](https://github.com/EanLee/article-write/pull/40)。
 
 ## 關聯文件
 
-- Bug Fix 報告：`docs/quality/assessments/fix-bug/2026-06-13-topic-020-e2e-acceptance-fixes.md`
-- 重現測試：`tests/e2e/writing-baseline.spec.ts`（`test.fixme` 標記的切換測試）
+- Bug Fix 報告（含追加修復）：`docs/quality/assessments/fix-bug/2026-06-13-topic-020-e2e-acceptance-fixes.md`
+- 修復測試：`tests/e2e/writing-baseline.spec.ts`（已移除 `test.fixme`）
 - 關聯議題：topic-020（儲存來源單一化，本問題於其 E2E 驗收階段發現）
+- 修復 PR：[#40](https://github.com/EanLee/article-write/pull/40)


### PR DESCRIPTION
## Summary

- topic-020 `decision.md` 回填儲存來源單一化（#2）、frontmatter 欄位保留（#3）已合併 develop 的事實
- 召開 T-020 技術會議，記錄排除的 4 個 reactivity 假設與範圍收斂過程
- 依 [PR #40](https://github.com/EanLee/article-write/pull/40) 的根因確認結果，標記 topic-021 已解決、T-020 Action Items #1/#3 完成，topic-020 #5/#7 解除阻塞，驗收標準四項全過

## Dependency

建議於 [PR #40](https://github.com/EanLee/article-write/pull/40) 合併後再合併本 PR（本 PR 內容引用其結論）。

## Test plan

- [x] 純文件變更，不影響程式碼