### PR TITLE
feat(store): 儲存衝突偵測改為內容 hash 比對並新增正式衝突彈窗

### DIFF
--- a/docs/engineering/discussions/topic-020-2026-06-13-save-race-data-overwrite/decision.md
+++ b/docs/engineering/discussions/topic-020-2026-06-13-save-race-data-overwrite/decision.md
@@ -48,7 +48,7 @@ source_of_truth: true
 
 | # | 行動項目 | 負責人 | 優先級 | 完成條件 | 狀態 |
 |---|---------|-------|-------|---------|------|
-| 1 | 過渡防護：寫入前 mtime/hash 比對＋衝突彈窗（含 E2E） | Sam | P0 | 半天內上線，衝突時彈窗詢問、不覆寫 | 🔄 進行中：`BackupService.detectConflict()` 已實作 mtime 比對，衝突時以 `notify.warning` 提示「重新載入」；尚缺 hash 比對與正式彈窗（目前為 toast） |
+| 1 | 過渡防護：寫入前 mtime/hash 比對＋衝突彈窗（含 E2E） | Sam | P0 | 半天內上線，衝突時彈窗詢問、不覆寫 | 🔄 進行中：`BackupService.detectConflict()` 已改為 hash 比對（FNV-1a），並新增 `SaveConflictDialog.vue` 正式三選一彈窗（重新載入／覆寫／取消），取代原 toast；unit test 已涵蓋。尚缺 E2E 覆蓋 |
 | 2 | 儲存來源單一化實作（A 方案，含切換時儲存路徑） | Taylor／技術團隊 | P0 | 三路徑統一取編輯器即時內容，unit + E2E 通過，1.5~2 天 | ✅ 完成（`84ac097 fix(store): 編輯器內容即時同步 store，統一儲存來源（topic-020 方案 A）`） |
 | 3 | frontmatter 序列化欄位保留修復 | Taylor／技術團隊 | P0 | date/draft 等欄位儲存後不遺失，同分支 | ✅ 完成（`1712aab fix(service): frontmatter 欄位完整保留與 own-write 衝突豁免`） |
 | 4 | 寫入後驗證＋Sentry 事件 | Sam | P1 | 不一致時可在 Sentry 看到事件 | ⏳ 待開始：尚無 Sentry 整合 |

--- a/src/components/MainEditor.vue
+++ b/src/components/MainEditor.vue
@@ -43,6 +43,9 @@
         <FrontmatterEditor v-model="showFrontmatterEditor" :article="articleStore.currentArticle"
             @update="handleFrontmatterUpdate" />
 
+        <!-- Save Conflict Dialog（topic-020 Action Item #1） -->
+        <SaveConflictDialog />
+
     </div>
 </template>
 
@@ -55,6 +58,7 @@ import EditorHeader from "./EditorHeader.vue";
 import CodeMirrorEditor from "./CodeMirrorEditor.vue";
 import PreviewPane from "./PreviewPane.vue";
 import FrontmatterEditor from "./FrontmatterEditor.vue";
+import SaveConflictDialog from "./SaveConflictDialog.vue";
 import SearchReplace from "./SearchReplace.vue";
 import { useServices } from "@/composables/useServices";
 import { useAutocomplete } from "@/composables/useAutocomplete";

--- a/src/components/SaveConflictDialog.vue
+++ b/src/components/SaveConflictDialog.vue
@@ -1,0 +1,35 @@
+<template>
+  <div v-if="conflictState" class="modal modal-open">
+    <div class="modal-box max-w-md">
+      <h3 class="font-bold text-lg mb-2">儲存衝突</h3>
+      <p class="text-sm text-base-content/80">
+        檔案「{{ conflictState.article.title }}」在外部被修改，與目前編輯器內容不一致。
+      </p>
+      <p v-if="modifiedTimeText" class="text-sm text-base-content/60 mt-1">
+        外部修改時間：{{ modifiedTimeText }}
+      </p>
+      <p class="text-sm text-base-content/80 mt-3">
+        請選擇要保留的版本：重新載入將捨棄編輯器中的變更，覆寫將以編輯器內容取代磁碟上的外部修改。
+      </p>
+
+      <div class="modal-action">
+        <button class="btn" @click="articleStore.resolveConflictCancel()">取消</button>
+        <button class="btn btn-outline" @click="articleStore.resolveConflictReload()">重新載入</button>
+        <button class="btn btn-warning" @click="articleStore.resolveConflictOverwrite()">覆寫</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useArticleStore } from "@/stores/article"
+
+const articleStore = useArticleStore()
+const conflictState = computed(() => articleStore.conflictState)
+
+const modifiedTimeText = computed(() => {
+  const time = conflictState.value?.fileModifiedTime
+  return time ? new Date(time).toLocaleString() : ""
+})
+</script>

--- a/src/services/ArticleService.ts
+++ b/src/services/ArticleService.ts
@@ -22,6 +22,18 @@ import type { BackupService } from "./BackupService";
 import { electronFileSystem } from "./ElectronFileSystem";
 import { logger } from "@/utils/logger";
 
+export interface SaveConflictDetails {
+  currentFileContent?: string;
+  fileModifiedTime?: Date;
+}
+
+export interface SaveResult {
+  success: boolean;
+  conflict?: boolean;
+  conflictDetails?: SaveConflictDetails;
+  error?: Error;
+}
+
 export class ArticleService {
   private fileSystem: IFileSystem;
   private markdownService: MarkdownService;
@@ -35,9 +47,9 @@ export class ArticleService {
   private saveQueues: Map<string, Promise<unknown>> = new Map();
 
   /**
-   * 自己最後寫入各檔案的內容（topic-020 own-write 豁免）
-   * 衝突偵測以 mtime 判斷，無法分辨「佇列中前一筆自己的寫入」與「外部修改」；
-   * 磁碟內容等於自己上次寫入時不視為衝突。
+   * 各檔案目前的磁碟內容基準（topic-020 衝突偵測）
+   * 由 loadArticle 讀取時、performSave 寫入後更新；存檔前比對磁碟現況的
+   * hash 與此基準的 hash，不同即代表檔案在外部被修改過。
    */
   private lastWrittenContent: Map<string, string> = new Map();
 
@@ -83,7 +95,7 @@ export class ArticleService {
       skipConflictCheck?: boolean;
       skipBackup?: boolean;
     } = {},
-  ): Promise<{ success: boolean; conflict?: boolean; error?: Error }> {
+  ): Promise<SaveResult> {
     // 同一檔案的儲存排入佇列依序執行；前一個儲存失敗不阻擋下一個
     const previous = this.saveQueues.get(article.filePath) ?? Promise.resolve();
     const current = previous.then(() => this.performSave(article, options));
@@ -108,19 +120,22 @@ export class ArticleService {
       skipConflictCheck?: boolean;
       skipBackup?: boolean;
     },
-  ): Promise<{ success: boolean; conflict?: boolean; error?: Error }> {
+  ): Promise<SaveResult> {
     try {
-      // 1. 衝突檢測（除非跳過）
+      // 1. 衝突檢測（除非跳過）：比對磁碟現況 hash 與基準 hash
       if (!options.skipConflictCheck) {
-        const conflictResult = await this.backupService.detectConflict(article);
-        // own-write 豁免：磁碟內容正是自己上次寫入的內容 → 非外部衝突
-        const isOwnWrite =
-          conflictResult.currentFileContent !== undefined &&
-          conflictResult.currentFileContent === this.lastWrittenContent.get(article.filePath);
-        if (conflictResult.hasConflict && !isOwnWrite) {
+        const conflictResult = await this.backupService.detectConflict(
+          article.filePath,
+          this.lastWrittenContent.get(article.filePath),
+        );
+        if (conflictResult.hasConflict) {
           return {
             success: false,
             conflict: true,
+            conflictDetails: {
+              currentFileContent: conflictResult.currentFileContent,
+              fileModifiedTime: conflictResult.fileModifiedTime,
+            },
           };
         }
       }
@@ -309,6 +324,9 @@ export class ArticleService {
     // 讀取檔案內容
     const content = await this.fileSystem.readFile(filePath);
     const { frontmatter, content: articleContent } = this.markdownService.parseMarkdown(content);
+
+    // 記錄目前磁碟內容作為衝突偵測的基準（topic-020）
+    this.lastWrittenContent.set(filePath, content);
 
     // 取得檔案的最後修改時間
     const fileStats = await this.fileSystem.getFileStats(filePath);

--- a/src/services/BackupService.ts
+++ b/src/services/BackupService.ts
@@ -1,6 +1,7 @@
 import type { Article } from "@/types";
 import type { IFileSystem } from "@/types/IFileSystem";
 import { electronFileSystem } from "./ElectronFileSystem";
+import { fnv1aHash } from "@/utils/hash";
 
 /**
  * 備份服務
@@ -78,22 +79,25 @@ export class BackupService {
   /**
    * 檢測衝突（檔案是否在外部被修改）
    */
-  async detectConflict(article: Article): Promise<ConflictResult> {
+  async detectConflict(filePath: string, baselineContent: string | undefined): Promise<ConflictResult> {
     try {
-      const stats = await this.fileSystem.getFileStats(article.filePath);
+      const stats = await this.fileSystem.getFileStats(filePath);
       if (!stats) {
         return { hasConflict: false };
       }
 
-      const fileModTime = new Date(stats.mtime);
-      const articleModTime = article.lastModified;
+      const currentContent = await this.fileSystem.readFile(filePath);
 
-      // 如果檔案修改時間比記錄的還要新，可能有衝突
-      if (fileModTime > articleModTime) {
-        const currentContent = await this.fileSystem.readFile(article.filePath);
+      // 基準內容未知時無法比對，視為無衝突（例如尚未載入過的新檔案）
+      if (baselineContent === undefined) {
+        return { hasConflict: false };
+      }
+
+      // 以內容 hash 比對，取代 mtime 比對：磁碟內容與基準內容不同即為外部修改
+      if (fnv1aHash(currentContent) !== fnv1aHash(baselineContent)) {
         return {
           hasConflict: true,
-          fileModifiedTime: fileModTime,
+          fileModifiedTime: new Date(stats.mtime),
           currentFileContent: currentContent,
         };
       }

--- a/src/stores/article.ts
+++ b/src/stores/article.ts
@@ -15,6 +15,28 @@ import { useFileWatching } from "@/composables/useFileWatching";
 import { useArticleFilter } from "@/composables/useArticleFilter";
 import { logger } from "@/utils/logger";
 
+/**
+ * 儲存衝突詳細資訊（topic-020 Action Item #1）
+ * 偵測到磁碟內容與基準不一致時，由 saveArticle 寫入此狀態，
+ * 交由 SaveConflictDialog 顯示並讓使用者選擇後續處理。
+ */
+export interface SaveConflict {
+  article: Article;
+  articleToSave: Article;
+  currentFileContent?: string;
+  fileModifiedTime?: Date;
+}
+
+/**
+ * 儲存衝突專用錯誤：與一般儲存失敗區分，避免重複跳出「儲存失敗」通知
+ */
+class SaveConflictError extends Error {
+  constructor() {
+    super("File conflict detected");
+    this.name = "SaveConflictError";
+  }
+}
+
 export const useArticleStore = defineStore("article", () => {
   // 使用服務單例
   const articleService = getArticleService();
@@ -23,6 +45,9 @@ export const useArticleStore = defineStore("article", () => {
   // State
   const articles = ref<Article[]>([]);
   const currentArticle = ref<Article | null>(null);
+
+  // 儲存衝突狀態（topic-020 Action Item #1）：非 null 時顯示 SaveConflictDialog
+  const conflictState = ref<SaveConflict | null>(null);
 
   // 檔案監聽 composable（在 handleFileChangeEvent 定義前用 let 聲明，函式稍後賦值）
   // SOLID6-01: 過濾與排序關注點提取到 useArticleFilter composable
@@ -231,7 +256,10 @@ export const useArticleStore = defineStore("article", () => {
    * ⚠️ 這個函數會執行實際的檔案寫入操作
    * 成功後會自動更新 store 狀態
    */
-  async function saveArticle(article: Article, options?: { preserveLastModified?: boolean }) {
+  async function saveArticle(
+    article: Article,
+    options?: { preserveLastModified?: boolean; skipConflictCheck?: boolean },
+  ) {
     try {
       assertElectronAvailable();
 
@@ -245,7 +273,9 @@ export const useArticleStore = defineStore("article", () => {
       fileWatchService.ignoreNextChange(articleToSave.filePath, 5000);
 
       // 使用 ArticleService 儲存（包含備份、衝突檢測、檔案寫入）
-      const result = await articleService.saveArticle(articleToSave);
+      const result = await articleService.saveArticle(articleToSave, {
+        skipConflictCheck: options?.skipConflictCheck,
+      });
 
       if (result.success) {
         // 儲存成功，只更新記憶體中的狀態，不觸發 reload
@@ -255,20 +285,22 @@ export const useArticleStore = defineStore("article", () => {
         // 若不同步會導致 UI 持續顯示「未儲存」直到下次自動儲存輪詢
         autoSaveService.notifySaved(articleToSave);
       } else if (result.conflict) {
-        // 檔案衝突
-        notify.warning("檔案衝突", "檔案在外部被修改，建議重新載入", {
-          action: {
-            label: "重新載入",
-            callback: () => reloadArticle(article.id),
-          },
-        });
-        throw new Error("File conflict detected");
+        // 檔案衝突：交由 SaveConflictDialog 顯示，讓使用者選擇重新載入／覆寫／取消
+        conflictState.value = {
+          article,
+          articleToSave,
+          currentFileContent: result.conflictDetails?.currentFileContent,
+          fileModifiedTime: result.conflictDetails?.fileModifiedTime,
+        };
+        throw new SaveConflictError();
       } else if (result.error) {
         throw result.error;
       }
     } catch (error) {
       logger.error("Failed to save article:", error);
-      notify.error("儲存失敗", error instanceof Error ? error.message : "無法儲存文章");
+      if (!(error instanceof SaveConflictError)) {
+        notify.error("儲存失敗", error instanceof Error ? error.message : "無法儲存文章");
+      }
       throw error;
     }
   }
@@ -492,6 +524,37 @@ export const useArticleStore = defineStore("article", () => {
     }
   }
 
+  /**
+   * 儲存衝突 - 重新載入：捨棄編輯器變更，以磁碟上的最新內容為準（topic-020）
+   */
+  async function resolveConflictReload() {
+    if (!conflictState.value) {
+      return;
+    }
+    const { article } = conflictState.value;
+    conflictState.value = null;
+    await reloadArticle(article.id);
+  }
+
+  /**
+   * 儲存衝突 - 覆寫：以編輯器內容覆蓋磁碟上的外部修改（topic-020）
+   */
+  async function resolveConflictOverwrite() {
+    if (!conflictState.value) {
+      return;
+    }
+    const { articleToSave } = conflictState.value;
+    conflictState.value = null;
+    await saveArticle(articleToSave, { skipConflictCheck: true, preserveLastModified: true });
+  }
+
+  /**
+   * 儲存衝突 - 取消：關閉對話框，維持編輯器內容不變、不寫入磁碟（topic-020）
+   */
+  function resolveConflictCancel() {
+    conflictState.value = null;
+  }
+
   // 初始化自動儲存服務  // 儲存狀態（橋接 AutoSaveService 純資料狀態為 Vue 響應式 ref）
   const saveState = ref<SaveState>({
     status: SaveStatus.Saved,
@@ -538,6 +601,7 @@ export const useArticleStore = defineStore("article", () => {
     currentArticle,
     filter,
     loading,
+    conflictState,
 
     // Getters
     filteredArticles,
@@ -561,6 +625,9 @@ export const useArticleStore = defineStore("article", () => {
     reloadArticle,
     saveCurrentArticle,
     initializeAutoSave,
+    resolveConflictReload,
+    resolveConflictOverwrite,
+    resolveConflictCancel,
     // 內部方法（供測試使用）
     reloadArticleFromDisk,
     removeArticleFromMemory,

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,12 @@
+/**
+ * FNV-1a hash（純 JS，同步，不依賴 Node.js Buffer 或 WebCrypto）
+ * 用於儲存衝突偵測時比對檔案內容是否一致
+ */
+export function fnv1aHash(input: string): string {
+  let h = 2166136261; // FNV-1a offset basis
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}

--- a/tests/services/ArticleService.test.ts
+++ b/tests/services/ArticleService.test.ts
@@ -136,6 +136,26 @@ Test content`;
 
       await expect(service.loadArticle(filePath, ArticleCategory.Software)).rejects.toThrow("File not found");
     });
+
+    it("載入後應記錄磁碟內容作為衝突偵測基準（topic-020）", async () => {
+      const filePath = "/vault/Drafts/Software/test-article.md";
+      const fileContent = `---
+title: Test Article
+date: 2026-01-26
+tags: [test]
+categories: [Software]
+---
+
+Test content`;
+
+      await mockFileSystem.createDirectory("/vault/Drafts/Software");
+      await mockFileSystem.writeFile(filePath, fileContent);
+
+      const article = await service.loadArticle(filePath, ArticleCategory.Software);
+      await service.saveArticle(article);
+
+      expect(mockDetectConflict).toHaveBeenCalledWith(filePath, fileContent);
+    });
   });
 
   describe("loadAllArticles", () => {
@@ -209,7 +229,7 @@ Test content`;
       // 驗證
       expect(result.success).toBe(true);
       expect(mockCombineContent).toHaveBeenCalled();
-      expect(mockDetectConflict).toHaveBeenCalledWith(article);
+      expect(mockDetectConflict).toHaveBeenCalledWith(article.filePath, undefined);
 
       // 驗證檔案已寫入
       const exists = await mockFileSystem.exists(article.filePath);
@@ -217,7 +237,12 @@ Test content`;
     });
 
     it("應該處理衝突情況", async () => {
-      mockDetectConflict.mockResolvedValueOnce({ hasConflict: true });
+      const fileModifiedTime = new Date("2026-01-27T00:00:00Z");
+      mockDetectConflict.mockResolvedValueOnce({
+        hasConflict: true,
+        currentFileContent: "外部程式改過的內容",
+        fileModifiedTime,
+      });
 
       const article: Article = {
         id: "test-id",
@@ -240,6 +265,8 @@ Test content`;
 
       expect(result.success).toBe(false);
       expect(result.conflict).toBe(true);
+      expect(result.conflictDetails?.currentFileContent).toBe("外部程式改過的內容");
+      expect(result.conflictDetails?.fileModifiedTime).toBe(fileModifiedTime);
     });
 
     it("應該支援跳過衝突檢查和備份", async () => {
@@ -310,7 +337,7 @@ Test content`;
       expect(finalContent).not.toContain("OLD content");
     });
 
-    it("磁碟內容等於自己上次寫入時不視為衝突（own-write 豁免，topic-020）", async () => {
+    it("儲存成功後，下次衝突偵測會以剛寫入的內容作為基準（topic-020 hash 比對基準）", async () => {
       const makeArticle = (content: string): Article => ({
         id: "test-id",
         title: "Test",
@@ -325,19 +352,13 @@ Test content`;
 
       await mockFileSystem.createDirectory("/vault/Drafts/Software");
 
-      // 第一筆儲存成功，service 記錄自己寫入的內容
+      // 第一筆儲存成功，service 記錄自己寫入的內容作為下次衝突偵測的基準
       const first = await service.saveArticle(makeArticle("FIRST content"));
       expect(first.success).toBe(true);
       const writtenByUs = await mockFileSystem.readFile("/vault/Drafts/Software/test.md");
 
-      // 衝突偵測回報 mtime 較新，但磁碟內容正是自己剛寫入的 → 不得視為衝突
-      mockDetectConflict.mockResolvedValueOnce({
-        hasConflict: true,
-        currentFileContent: writtenByUs,
-      });
-      const second = await service.saveArticle(makeArticle("SECOND content"));
-      expect(second.success).toBe(true);
-      expect(await mockFileSystem.readFile("/vault/Drafts/Software/test.md")).toContain("SECOND content");
+      await service.saveArticle(makeArticle("SECOND content"));
+      expect(mockDetectConflict).toHaveBeenLastCalledWith("/vault/Drafts/Software/test.md", writtenByUs);
     });
 
     it("磁碟內容與自己上次寫入不同時維持衝突判定（真外部修改）", async () => {

--- a/tests/services/BackupService.test.ts
+++ b/tests/services/BackupService.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest"
 import { BackupService } from "@/services/BackupService"
 import type { Article } from "@/types"
 import { ArticleStatus, ArticleCategory } from "@/types"
+import { MockFileSystem } from "../mocks/MockFileSystem"
 
 describe("BackupService", () => {
   let backupService: BackupService
@@ -94,6 +95,51 @@ describe("BackupService", () => {
       expect(stats.totalBackups).toBe(0)
       expect(stats.oldestBackup).toBeNull()
       expect(stats.newestBackup).toBeNull()
+    })
+  })
+
+  describe("detectConflict（topic-020 hash 比對）", () => {
+    const filePath = "/test/path/test-article.md"
+
+    it("檔案不存在時不視為衝突", async () => {
+      const mockFileSystem = new MockFileSystem()
+      const service = new BackupService(mockFileSystem)
+
+      const result = await service.detectConflict(filePath, "baseline content")
+
+      expect(result.hasConflict).toBe(false)
+    })
+
+    it("基準內容未知（尚未載入過）時不視為衝突", async () => {
+      const mockFileSystem = new MockFileSystem()
+      await mockFileSystem.writeFile(filePath, "目前磁碟內容")
+      const service = new BackupService(mockFileSystem)
+
+      const result = await service.detectConflict(filePath, undefined)
+
+      expect(result.hasConflict).toBe(false)
+    })
+
+    it("磁碟內容與基準一致時不視為衝突（own-write 豁免）", async () => {
+      const mockFileSystem = new MockFileSystem()
+      await mockFileSystem.writeFile(filePath, "相同內容")
+      const service = new BackupService(mockFileSystem)
+
+      const result = await service.detectConflict(filePath, "相同內容")
+
+      expect(result.hasConflict).toBe(false)
+    })
+
+    it("磁碟內容與基準不同時視為衝突，並回傳目前內容與修改時間", async () => {
+      const mockFileSystem = new MockFileSystem()
+      await mockFileSystem.writeFile(filePath, "外部程式改過的內容")
+      const service = new BackupService(mockFileSystem)
+
+      const result = await service.detectConflict(filePath, "原始基準內容")
+
+      expect(result.hasConflict).toBe(true)
+      expect(result.currentFileContent).toBe("外部程式改過的內容")
+      expect(result.fileModifiedTime).toBeInstanceOf(Date)
     })
   })
 

--- a/tests/stores/article.actions.test.ts
+++ b/tests/stores/article.actions.test.ts
@@ -122,6 +122,81 @@ describe("Article Store — Actions 補強", () => {
     });
   });
 
+  describe("儲存衝突處理（topic-020 Action Item #1）", () => {
+    it("磁碟內容與基準不一致時，設定 conflictState 並拋出錯誤", async () => {
+      const store = useArticleStore();
+      const article = makeArticle();
+      store.articles.push(article);
+      store.setCurrentArticle(article);
+
+      // 第一次儲存成功，記錄目前寫入內容作為基準
+      await store.saveArticle(article);
+
+      // 模擬檔案在外部被修改
+      mockElectronAPI.getFileStats.mockResolvedValue({ isDirectory: false, mtime: Date.now(), size: 100 });
+      mockElectronAPI.readFile.mockResolvedValue("外部程式改過的內容");
+
+      await expect(store.saveArticle(article)).rejects.toThrow();
+
+      expect(store.conflictState).not.toBeNull();
+      expect(store.conflictState?.currentFileContent).toBe("外部程式改過的內容");
+      expect(store.conflictState?.article.id).toBe(article.id);
+    });
+
+    it("resolveConflictCancel 清除 conflictState 且不寫入檔案", async () => {
+      const store = useArticleStore();
+      const article = makeArticle();
+      store.articles.push(article);
+      store.setCurrentArticle(article);
+      await store.saveArticle(article);
+
+      mockElectronAPI.getFileStats.mockResolvedValue({ isDirectory: false, mtime: Date.now(), size: 100 });
+      mockElectronAPI.readFile.mockResolvedValue("外部程式改過的內容");
+      await expect(store.saveArticle(article)).rejects.toThrow();
+
+      mockElectronAPI.writeFile.mockClear();
+      store.resolveConflictCancel();
+
+      expect(store.conflictState).toBeNull();
+      expect(mockElectronAPI.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("resolveConflictOverwrite 以編輯器內容覆寫磁碟並清除 conflictState", async () => {
+      const store = useArticleStore();
+      const article = makeArticle();
+      store.articles.push(article);
+      store.setCurrentArticle(article);
+      await store.saveArticle(article);
+
+      mockElectronAPI.getFileStats.mockResolvedValue({ isDirectory: false, mtime: Date.now(), size: 100 });
+      mockElectronAPI.readFile.mockResolvedValue("外部程式改過的內容");
+      await expect(store.saveArticle(article)).rejects.toThrow();
+
+      mockElectronAPI.writeFile.mockClear();
+      await store.resolveConflictOverwrite();
+
+      expect(store.conflictState).toBeNull();
+      expect(mockElectronAPI.writeFile).toHaveBeenCalledWith(article.filePath, expect.any(String));
+    });
+
+    it("resolveConflictReload 以磁碟內容重新載入並清除 conflictState", async () => {
+      const store = useArticleStore();
+      const article = makeArticle();
+      store.articles.push(article);
+      store.setCurrentArticle(article);
+      await store.saveArticle(article);
+
+      mockElectronAPI.getFileStats.mockResolvedValue({ isDirectory: false, mtime: Date.now(), size: 100 });
+      mockElectronAPI.readFile.mockResolvedValue("外部程式改過的內容");
+      await expect(store.saveArticle(article)).rejects.toThrow();
+
+      await store.resolveConflictReload();
+
+      expect(store.conflictState).toBeNull();
+      expect(store.currentArticle?.content).toBe("外部程式改過的內容");
+    });
+  });
+
   describe("saveCurrentArticle", () => {
     it("無 currentArticle 時不拋出錯誤", async () => {
       const store = useArticleStore();

--- a/tests/utils/hash.test.ts
+++ b/tests/utils/hash.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { fnv1aHash } from "@/utils/hash"
+
+describe("fnv1aHash", () => {
+  it("相同字串應產生相同 hash", () => {
+    expect(fnv1aHash("hello world")).toBe(fnv1aHash("hello world"))
+  })
+
+  it("不同字串應產生不同 hash", () => {
+    expect(fnv1aHash("hello world")).not.toBe(fnv1aHash("hello world!"))
+  })
+
+  it("空字串應可正常處理", () => {
+    expect(fnv1aHash("")).toBe(fnv1aHash(""))
+  })
+
+  it("回傳值應為固定長度的 16 進位字串", () => {
+    expect(fnv1aHash("test")).toMatch(/^[0-9a-f]{8}$/)
+  })
+})


### PR DESCRIPTION
## Summary
- topic-020 過渡防護過去以 mtime 比對偵測外部修改，且僅以 toast 提示「重新載入」，未提供明確處理選項，own-write 豁免邏輯也分散在 ArticleService
- `BackupService.detectConflict()` 改為以 FNV-1a 內容 hash 比對磁碟現況與基準內容（`loadArticle`/`performSave` 記錄），不一致才視為外部修改
- 新增 `SaveConflictDialog.vue`，提供「重新載入／覆寫／取消」三選一，取代原 toast，並統一 own-write 豁免邏輯
- `src/stores/article.ts` 新增 `conflictState`、`resolveConflictReload/Overwrite/Cancel`
- 同步更新 topic-020 decision.md Action Item #1 狀態
- topic-020 Action Item #1（#4 Sentry 整合、#6 已知問題清單文案不在此分支範圍）

## Test plan
- [x] 新增/更新 `BackupService.test.ts`、`ArticleService.test.ts`、`article.actions.test.ts`、`hash.test.ts`
- [x] `pnpm run test` 全套件通過（641 passed | 1 skipped，0 failures）
- [ ] E2E 衝突彈窗情境覆蓋（尚未補，留待後續）