### PR TITLE
refactor(autosave): 統一自動存檔機制並修正時序問題

### DIFF
--- a/src/components/MainEditor.vue
+++ b/src/components/MainEditor.vue
@@ -80,7 +80,6 @@ const isLoadingArticle = ref(false); // 防止文章載入時誤觸 AutoSave
 const showPreview = ref(false);
 const showFrontmatterEditor = ref(false);
 const renderedContent = ref("");
-const autoSaveTimer = ref<number | null>(null);
 const editorMode = ref<"compose" | "raw">("compose");
 const rawContent = ref("");
 
@@ -240,8 +239,7 @@ function handleContentChange() {
     // Trigger validation
     debounceValidation();
 
-    // 排程自動儲存（會調用 service）
-    scheduleAutoSave();
+    autoSaveService.markAsModified();
 }
 
 // Watch content changes
@@ -266,21 +264,6 @@ watch(content, (newContent) => {
         }, 500);
     }
 });
-
-function scheduleAutoSave() {
-    // 文章載入期間不觸發自動儲存（避免開啟文件即誤觸儲存）
-    if (isLoadingArticle.value) {
-        return;
-    }
-
-    if (autoSaveTimer.value) {
-        clearTimeout(autoSaveTimer.value);
-    }
-
-    autoSaveTimer.value = setTimeout(() => {
-        saveArticle();
-    }, 2000) as unknown as number; // Auto-save after 2 seconds of inactivity
-}
 
 async function saveArticle() {
     if (!articleStore.currentArticle) {
@@ -363,14 +346,10 @@ function toggleEditorMode() {
     isSwitchingMode.value = true;
 
     try {
-        // 清理所有定時器，防止在模式切換後訪問已卸載的 ref
+        // 清理歷史記錄定時器，防止在模式切換後訪問已卸載的 ref
         if (historyTimeout) {
             clearTimeout(historyTimeout);
             historyTimeout = null;
-        }
-        if (autoSaveTimer.value) {
-            clearTimeout(autoSaveTimer.value);
-            autoSaveTimer.value = null;
         }
 
         if (editorMode.value === "compose") {
@@ -424,8 +403,7 @@ function handleRawContentChange() {
             logger.warn("[RawMode] Frontmatter 解析警告:", parsed.errors);
         }
 
-        // 排程自動儲存（會通過 service 更新 store）
-        scheduleAutoSave();
+        autoSaveService.markAsModified();
 
         if (showPreview.value) {
             updatePreview();
@@ -665,10 +643,6 @@ onMounted(() => {
 
 // Cleanup
 onUnmounted(() => {
-    // 清理自動儲存定時器
-    if (autoSaveTimer.value) {
-        clearTimeout(autoSaveTimer.value);
-    }
     // 清理歷史記錄定時器
     if (historyTimeout) {
         clearTimeout(historyTimeout);

--- a/src/services/AutoSaveService.ts
+++ b/src/services/AutoSaveService.ts
@@ -55,12 +55,19 @@ export class AutoSaveService {
    * @param {(article: Article) => Promise<void>} saveCallback - 儲存文章的回調函數
    * @param {() => Article | null} getCurrentArticleCallback - 取得當前文章的回調函數
    * @param {number} interval - 自動儲存間隔（毫秒），預設 30 秒
+   * @param {boolean} enabled - 是否啟用，預設沿用當前狀態
    */
-  initialize(saveCallback: (article: Article) => Promise<void>, getCurrentArticleCallback: () => Article | null, interval: number = 30000): void {
+  initialize(
+    saveCallback: (article: Article) => Promise<void>,
+    getCurrentArticleCallback: () => Article | null,
+    interval: number = 30000,
+    enabled: boolean = this.isEnabled,
+  ): void {
     this.saveCallback = saveCallback;
     this.getCurrentArticleCallback = getCurrentArticleCallback;
     this.autoSaveInterval = interval;
-    this.initialized = true; // 標記為已初始化
+    this.isEnabled = enabled;
+    this.initialized = true;
 
     if (this.isEnabled) {
       this.startAutoSave();
@@ -271,11 +278,10 @@ export class AutoSaveService {
    * @param {boolean} enabled - 是否啟用
    */
   setEnabled(enabled: boolean): void {
+    if (this.isEnabled === enabled) {return;}
     this.isEnabled = enabled;
 
-    if (!this.initialized) {
-      return;
-    }
+    if (!this.initialized) {return;}
 
     if (enabled) {
       this.startAutoSave();
@@ -289,9 +295,9 @@ export class AutoSaveService {
    * @param {number} interval - 間隔時間（毫秒）
    */
   setInterval(interval: number): void {
+    if (this.autoSaveInterval === interval) {return;}
     this.autoSaveInterval = interval;
 
-    // 如果自動儲存正在運行，重新啟動以套用新間隔
     if (this.autoSaveTimer) {
       this.startAutoSave();
     }

--- a/src/services/AutoSaveService.ts
+++ b/src/services/AutoSaveService.ts
@@ -158,6 +158,9 @@ export class AutoSaveService {
       logger.warn("AutoSaveService: Cannot save on article switch before initialization");
       return;
     }
+    if (!this.isEnabled) {
+      return;
+    }
     if (!this.saveCallback || !previousArticle) {
       return;
     }

--- a/src/services/AutoSaveService.ts
+++ b/src/services/AutoSaveService.ts
@@ -158,14 +158,12 @@ export class AutoSaveService {
   /**
    * 文章切換時的自動儲存
    * 在切換到新文章前儲存當前文章
+   * 刻意不檢查 isEnabled：這是防止資料遺失的安全網，與使用者是否關閉定期自動儲存計時器無關
    * @param {Article | null} previousArticle - 前一篇文章
    */
   async saveOnArticleSwitch(previousArticle: Article | null): Promise<void> {
     if (!this.initialized) {
       logger.warn("AutoSaveService: Cannot save on article switch before initialization");
-      return;
-    }
-    if (!this.isEnabled) {
       return;
     }
     if (!this.saveCallback || !previousArticle) {

--- a/src/stores/article.ts
+++ b/src/stores/article.ts
@@ -573,13 +573,11 @@ export const useArticleStore = defineStore("article", () => {
     const interval = config.editorConfig.autoSaveInterval || 30000;
 
     autoSaveService.initialize(
-      saveArticle, // ✅ 使用新的 saveArticle 函數（會寫入檔案）
+      saveArticle,
       () => currentArticle.value,
       interval,
+      config.editorConfig.autoSave,
     );
-
-    // 根據設定啟用或停用自動儲存
-    autoSaveService.setEnabled(config.editorConfig.autoSave);
   }
 
   // 監聽設定變更以更新自動儲存

--- a/src/stores/article.ts
+++ b/src/stores/article.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, watch, nextTick } from "vue";
+import { ref, watch } from "vue";
 import type { Article, SaveState } from "@/types";
 import { ArticleStatus, SaveStatus } from "@/types";
 import { autoSaveService } from "@/services/AutoSaveService";
@@ -580,7 +580,7 @@ export const useArticleStore = defineStore("article", () => {
     );
   }
 
-  // 監聽設定變更以更新自動儲存
+  // 監聽設定變更以更新自動儲存間隔與啟用狀態
   watch(
     () => configStore.config.editorConfig,
     (newConfig) => {
@@ -589,11 +589,18 @@ export const useArticleStore = defineStore("article", () => {
     },
     { deep: true },
   );
-  // 初始化自動儲存：使用 nextTick 取代任意 setTimeout(100ms)，
-  // 確保 Vue 響應式系統完成當前 tick 後再初始化，語意明確且可測試
-  nextTick(() => {
-    initializeAutoSave();
-  });
+  // 等 loadConfig() 完成（loading: true → false）後才初始化，確保拿到磁碟存的 config
+  // 避免 nextTick 比 IPC 回傳更早，導致以預設值（autoSave: true）啟動後又被 watch 停掉
+  let autoSaveReady = false;
+  watch(
+    () => configStore.loading,
+    (isLoading) => {
+      if (!isLoading && !autoSaveReady) {
+        autoSaveReady = true;
+        initializeAutoSave();
+      }
+    },
+  );
 
   return {
     // State

--- a/tests/services/AutoSaveService.test.ts
+++ b/tests/services/AutoSaveService.test.ts
@@ -127,6 +127,15 @@ describe("AutoSaveService", () => {
       expect(mockSaveCallback).toHaveBeenCalledWith(modifiedArticle);
     });
 
+    it("即使使用者關閉定期自動儲存，切換文章仍應儲存前一篇（避免資料遺失）", async () => {
+      autoSaveService.initialize(mockSaveCallback, mockGetCurrentArticleCallback, 30000, false);
+
+      const modifiedArticle = { ...mockArticle, content: "Modified content" };
+      await autoSaveService.saveOnArticleSwitch(modifiedArticle);
+
+      expect(mockSaveCallback).toHaveBeenCalledWith(modifiedArticle);
+    });
+
     it("應該能夠手動觸發儲存", async () => {
       autoSaveService.initialize(mockSaveCallback, mockGetCurrentArticleCallback);
 


### PR DESCRIPTION
## 內容
- 移除 MainEditor 獨立的 2 秒自動存檔定時器，統一由 AutoSaveService 管理
- 修正啟動/停止重複觸發兩次的問題（setEnabled/setInterval 加冪等保護）
- 修正初始化時序：改用 configStore.loading watch，避免 loadConfig() 完成前以預設值啟動又被 watch 停掉

## 來源
從長期停滯（落後 develop 22 commits）的 refactor/consolidate-autosave-timer 分支拆分重整而來，僅保留與自動存檔相關、彼此獨立可驗證的部分。

## 驗證
- `pnpm run test`：683 passed
- `pnpm run lint`：0 errors