### PR TITLE
feat(logging): 整合 electron-log 統一 main/renderer 日誌

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/markdown-it": "^14.1.2",
     "chokidar": "^5.0.0",
     "dompurify": "^3.4.11",
+    "electron-log": "^5.4.4",
     "electron-updater": "^6.8.9",
     "highlight.js": "^11.11.1",
     "js-yaml": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       dompurify:
         specifier: ^3.4.11
         version: 3.4.11
+      electron-log:
+        specifier: ^5.4.4
+        version: 5.4.4
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9
@@ -1988,6 +1991,10 @@ packages:
     resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  electron-log@5.4.4:
+    resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
+    engines: {node: '>= 14'}
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
@@ -5868,6 +5875,8 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
+
+  electron-log@5.4.4: {}
 
   electron-publish@26.15.3:
     dependencies:

--- a/src/__mocks__/electron-log.ts
+++ b/src/__mocks__/electron-log.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+/** electron-log test stub — replaces all electron-log sub-paths in Vitest via alias */
+const noop = () => {};
+
+const stub = {
+  // Use arrow functions so vi.spyOn replacements are picked up at call time
+  debug: (...a: unknown[]) => console.debug(...a),
+  info: (...a: unknown[]) => console.info(...a),
+  warn: (...a: unknown[]) => console.warn(...a),
+  error: (...a: unknown[]) => console.error(...a),
+  initialize: noop,
+  transports: {
+    file: { level: false as const },
+    console: { level: "warn" as const },
+  },
+};
+
+export default stub;

--- a/src/main/electron-log-preload.d.ts
+++ b/src/main/electron-log-preload.d.ts
@@ -1,0 +1,1 @@
+declare module "electron-log/preload" {}

--- a/src/main/mainLogger.ts
+++ b/src/main/mainLogger.ts
@@ -14,21 +14,16 @@ const isDev = process.env.NODE_ENV !== "production";
 log.initialize();
 
 // resolvePathFn 在第一次寫 log 時才執行；variables.userData 由 electron-log 自動解析
-log.transports.file.resolvePathFn = (variables) => {
-  const p = join(variables.userData ?? app.getPath("userData"), "logs", "main.log");
-  console.log("[mainLogger] log file path:", p);
-  return p;
-};
+log.transports.file.resolvePathFn = (variables) =>
+  join(variables.userData ?? app.getPath("userData"), "logs", "main.log");
 
 if (isDev) {
   log.transports.file.level = "debug";
   log.transports.console.level = "debug";
   log.transports.file.format = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}";
-  console.log("[mainLogger] isDev=true, file.level=debug");
 } else {
   log.transports.file.level = false;
   log.transports.console.level = "warn";
-  console.log("[mainLogger] isDev=false, file logging DISABLED");
 }
 
 export const logger = {

--- a/src/main/mainLogger.ts
+++ b/src/main/mainLogger.ts
@@ -1,22 +1,34 @@
 /**
  * Main Process Logger
- * Dev 模式：同時輸出到終端機與 log 檔（%AppData%\WriteFlow\logs\main.log）
+ * Dev 模式：同時輸出到終端機與 log 檔（%AppData%\{appName}\logs\main.log）
  * Prod 模式：僅輸出 warn/error 到終端機，不寫檔
  */
 
 import log from "electron-log/main";
+import { app } from "electron";
+import { join } from "node:path";
 
 const isDev = process.env.NODE_ENV !== "production";
 
+// initialize() 須在 app.ready 前呼叫（設定 IPC handler）
 log.initialize();
+
+// resolvePathFn 在第一次寫 log 時才執行；variables.userData 由 electron-log 自動解析
+log.transports.file.resolvePathFn = (variables) => {
+  const p = join(variables.userData ?? app.getPath("userData"), "logs", "main.log");
+  console.log("[mainLogger] log file path:", p);
+  return p;
+};
 
 if (isDev) {
   log.transports.file.level = "debug";
   log.transports.console.level = "debug";
   log.transports.file.format = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}";
+  console.log("[mainLogger] isDev=true, file.level=debug");
 } else {
   log.transports.file.level = false;
   log.transports.console.level = "warn";
+  console.log("[mainLogger] isDev=false, file logging DISABLED");
 }
 
 export const logger = {

--- a/src/main/mainLogger.ts
+++ b/src/main/mainLogger.ts
@@ -1,25 +1,35 @@
 /**
  * Main Process Logger
- * 在開發環境下輸出 debug/info 日誌，在生產環境只輸出 warn/error
+ * Dev 模式：同時輸出到終端機與 log 檔（%AppData%\WriteFlow\logs\main.log）
+ * Prod 模式：僅輸出 warn/error 到終端機，不寫檔
  */
+
+import log from "electron-log/main";
 
 const isDev = process.env.NODE_ENV !== "production";
 
+log.initialize();
+
+if (isDev) {
+  log.transports.file.level = "debug";
+  log.transports.console.level = "debug";
+  log.transports.file.format = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}";
+} else {
+  log.transports.file.level = false;
+  log.transports.console.level = "warn";
+}
+
 export const logger = {
   debug: (...args: unknown[]): void => {
-    if (isDev) {
-      console.log("[DEBUG]", ...args);
-    }
+    if (isDev) {log.debug(...args);}
   },
   info: (...args: unknown[]): void => {
-    if (isDev) {
-      console.info("[INFO]", ...args);
-    }
+    if (isDev) {log.info(...args);}
   },
   warn: (...args: unknown[]): void => {
-    console.warn("[WARN]", ...args);
+    log.warn(...args);
   },
   error: (...args: unknown[]): void => {
-    console.error("[ERROR]", ...args);
+    log.error(...args);
   },
 };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { IPC } from "./ipc-channels.js";
-import "electron-log/preload";
 
 contextBridge.exposeInMainWorld("electronAPI", {
   // File operations

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { IPC } from "./ipc-channels.js";
-import { exposeElectronLog } from "electron-log/preload";
+import "electron-log/preload";
 
 contextBridge.exposeInMainWorld("electronAPI", {
   // File operations
@@ -103,4 +103,3 @@ contextBridge.exposeInMainWorld("electronAPI", {
   aiGetActiveProvider: () => ipcRenderer.invoke(IPC.AI_GET_ACTIVE_PROVIDER),
 });
 
-exposeElectronLog();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { IPC } from "./ipc-channels.js";
+import { exposeElectronLog } from "electron-log/preload";
 
 contextBridge.exposeInMainWorld("electronAPI", {
   // File operations
@@ -101,3 +102,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
   aiHasApiKey: (provider: string) => ipcRenderer.invoke(IPC.AI_GET_HAS_API_KEY, provider),
   aiGetActiveProvider: () => ipcRenderer.invoke(IPC.AI_GET_ACTIVE_PROVIDER),
 });
+
+exposeElectronLog();

--- a/src/main/services/PublishService.ts
+++ b/src/main/services/PublishService.ts
@@ -1,4 +1,4 @@
-import { logger } from "../../utils/logger.js"
+import { logger } from "../mainLogger.js"
 import { join } from "node:path"
 import { promises as fs } from "node:fs"
 import type { Article } from "../../types/index.js"

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,40 +1,24 @@
 /**
- * Logger 工具
- * 在開發環境下輸出 debug/info 日誌，在生產環境只輸出 warn/error
+ * Renderer Process Logger
+ * Dev 模式：透過 electron-log IPC bridge 寫入與 main process 共用的 log 檔
+ * Prod 模式：僅輸出 warn/error 到 console
  */
+
+import log from "electron-log/renderer";
 
 const isDev = process.env.NODE_ENV !== "production";
 
 export const logger = {
-  /**
-   * 除錯日誌（僅在開發環境輸出）
-   */
   debug: (...args: unknown[]): void => {
-    if (isDev) {
-      console.log("[DEBUG]", ...args);
-    }
+    if (isDev) {log.debug(...args);}
   },
-
-  /**
-   * 資訊日誌（僅在開發環境輸出）
-   */
   info: (...args: unknown[]): void => {
-    if (isDev) {
-      console.info("[INFO]", ...args);
-    }
+    if (isDev) {log.info(...args);}
   },
-
-  /**
-   * 警告日誌（總是輸出）
-   */
   warn: (...args: unknown[]): void => {
-    console.warn("[WARN]", ...args);
+    log.warn(...args);
   },
-
-  /**
-   * 錯誤日誌（總是輸出）
-   */
   error: (...args: unknown[]): void => {
-    console.error("[ERROR]", ...args);
+    log.error(...args);
   },
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,7 @@
 /**
  * Renderer Process Logger
- * Dev 模式：透過 electron-log IPC bridge 寫入與 main process 共用的 log 檔
- * Prod 模式：僅輸出 warn/error 到 console
+ * Electron 環境：透過 electron-log IPC bridge 寫入與 main process 共用的 log 檔
+ * 非 Electron 環境（測試 / 瀏覽器）：vitest alias → __mocks__/electron-log fallback
  */
 
 import log from "electron-log/renderer";
@@ -10,10 +10,10 @@ const isDev = process.env.NODE_ENV !== "production";
 
 export const logger = {
   debug: (...args: unknown[]): void => {
-    if (isDev) {log.debug(...args);}
+    if (isDev) { log.debug(...args); }
   },
   info: (...args: unknown[]): void => {
-    if (isDev) {log.info(...args);}
+    if (isDev) { log.info(...args); }
   },
   warn: (...args: unknown[]): void => {
     log.warn(...args);

--- a/tests/services/AutoSaveService.test.ts
+++ b/tests/services/AutoSaveService.test.ts
@@ -188,7 +188,7 @@ describe("AutoSaveService", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (autoSaveService as any).performAutoSave();
 
-      expect(consoleSpy).toHaveBeenCalledWith("[ERROR]", "自動儲存失敗:", expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.any(String), expect.any(Error));
       expect(autoSaveService.getStatus().running).toBe(true);
 
       consoleSpy.mockRestore();

--- a/tsconfig.preload.json
+++ b/tsconfig.preload.json
@@ -19,5 +19,5 @@
     "typeRoots": ["./node_modules/@types"],
     "types": ["node"]
   },
-  "include": ["src/main/preload.ts"]
+  "include": ["src/main/preload.ts", "src/main/**/*.d.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,7 +31,11 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src')
+      '@': resolve(__dirname, 'src'),
+      // electron-log sub-paths hang in jsdom (no ipcRenderer) — redirect to console stub
+      'electron-log/renderer': resolve(__dirname, 'src/__mocks__/electron-log.ts'),
+      'electron-log/main': resolve(__dirname, 'src/__mocks__/electron-log.ts'),
+      'electron-log/preload': resolve(__dirname, 'src/__mocks__/electron-log.ts'),
     }
   }
 })


### PR DESCRIPTION
## 內容
- 安裝 electron-log v5，dev 模式下 main/renderer 所有 log 統一寫入 log 檔
- 修正 preload 引入方式與型別宣告
- 修正 electron-log 在 Vitest jsdom 環境下卡住（新增 __mocks__/electron-log.ts + vitest alias）
- 修正三項根因：preload 衝突、resolvePathFn 改用官方 variables.userData、PublishService 改用 main logger
- 移除 mainLogger 診斷用 console.log 輸出
- 更新 AutoSaveService 測試斷言以符合新 logger 呼叫格式

## 來源
從長期停滯（落後 develop 22 commits）的 refactor/consolidate-autosave-timer 分支拆分重整而來。

## 驗證
- `pnpm run test`：683 passed
- `pnpm run lint`：0 errors

## 注意
`test/behavior-based-assertions` PR 疊在此分支之上，建議此 PR 先合併。