### PR TITLE
fix(settings): 修正選取資料夾多次點擊與 config 欄位名稱不一致

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,21 +1,23 @@
 
-
-# list of languages for which language servers are started; choose from:
-#   al                  angular             ansible             bash                clojure
-#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
-#   dart                elixir              elm                 erlang              fortran
-#   fsharp              go                  groovy              haskell             haxe
-#   hlsl                html                java                json                julia
-#   kotlin              lean4               lua                 luau                markdown
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
 #   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        powershell          python
-#   python_jedi         python_ty           r                   rego                ruby
-#   ruby_solargraph     rust                scala               scss                solidity
-#   svelte              swift               systemverilog       terraform           toml
-#   typescript          typescript_vts      vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
@@ -57,7 +59,7 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "R"
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
@@ -125,17 +127,42 @@ ignored_memory_patterns: []
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
 
-# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# list of additional workspace folder paths for cross-package reference support.
 # Paths can be absolute or relative to the project root.
 # Each folder is registered as an LSP workspace folder, enabling language servers to discover
-# symbols and references across package boundaries.
-# Currently supported for: TypeScript.
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
 # Example:
 #   additional_workspace_folders:
 #     - ../sibling-package
 #     - ../shared-lib
-additional_workspace_folders: []
+ls_additional_workspace_folders: []
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .

--- a/env.d.ts
+++ b/env.d.ts
@@ -44,7 +44,7 @@ interface SyncResult {
 interface AppConfigShape {
   paths: {
     articlesDir: string;
-    targetBlog: string;
+    targetDir: string;
     imagesDir: string;
   };
   editorConfig: {

--- a/src/components/ServerControlPanel.vue
+++ b/src/components/ServerControlPanel.vue
@@ -137,7 +137,7 @@ const logPanelHeight = ref(200)
 const logContainerRef = ref<HTMLElement>()
 
 // Computed
-const hasTargetBlog = computed(() => !!configStore.config.paths.targetBlog)
+const hasTargetBlog = computed(() => !!configStore.config.paths.targetDir)
 
 const statusIndicatorClass = computed(() => {
   if (loading.value) {return "bg-warning animate-pulse"}
@@ -163,7 +163,7 @@ async function startServer() {
 
   loading.value = true
   try {
-    await globalThis.electronAPI.startDevServer(configStore.config.paths.targetBlog)
+    await globalThis.electronAPI.startDevServer(configStore.config.paths.targetDir)
     await updateStatus()
   } catch (error) {
     logger.error("啟動伺服器失敗:", error)

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -618,6 +618,7 @@
 import { ref, computed, watch } from "vue"
 import { useConfigStore } from "@/stores/config"
 import { useArticleStore } from "@/stores/article"
+import { logger } from "@/utils/logger"
 import type { AppConfig } from "@/types"
 
 interface Props {

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -103,7 +103,7 @@
                       class="input input-bordered join-item flex-1"
                       :class="{ 'input-error': localConfig.paths.articlesDir && !articlesValidation.valid }"
                     />
-                    <button class="btn btn-primary join-item" @click="selectArticlesPath">
+                    <button class="btn btn-primary join-item" :disabled="isSelectingPath" @click="selectArticlesPath">
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z" />
                       </svg>
@@ -143,20 +143,20 @@
                   </p>
                   <div class="join w-full">
                     <input
-                      v-model="localConfig.paths.targetBlog"
+                      v-model="localConfig.paths.targetDir"
                       type="text"
                       placeholder="例如：C:\Users\你的名字\Projects\my-blog\src\content\blog"
                       class="input input-bordered join-item flex-1"
-                      :class="{ 'input-error': localConfig.paths.targetBlog && !blogValidation.valid && !blogValidation.warning }"
+                      :class="{ 'input-error': localConfig.paths.targetDir && !blogValidation.valid && !blogValidation.warning }"
                     />
-                    <button class="btn btn-primary join-item" @click="selectBlogPath">
+                    <button class="btn btn-primary join-item" :disabled="isSelectingPath" @click="selectBlogPath">
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z" />
                       </svg>
                       選擇資料夾
                     </button>
                   </div>
-                  <div v-if="localConfig.paths.targetBlog" class="flex items-center gap-2 mt-2">
+                  <div v-if="localConfig.paths.targetDir" class="flex items-center gap-2 mt-2">
                     <div
                       class="w-3 h-3 rounded-full"
                       :class="blogValidation.valid && !blogValidation.warning ? 'bg-success' : blogValidation.warning ? 'bg-warning' : 'bg-error'"
@@ -194,7 +194,7 @@
                       placeholder="留空使用預設路徑"
                       class="input input-bordered join-item flex-1"
                     />
-                    <button class="btn btn-outline join-item" @click="selectImagesPath">
+                    <button class="btn btn-outline join-item" :disabled="isSelectingPath" @click="selectImagesPath">
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z" />
                       </svg>
@@ -671,7 +671,7 @@ async function saveAiApiKey(provider: string) {
 const localConfig = ref<AppConfig>({
   paths: {
     articlesDir: "",
-    targetBlog: "",
+    targetDir: "",
     imagesDir: ""
   },
   editorConfig: {
@@ -692,6 +692,7 @@ const autoSaveSeconds = computed({
 // Validation
 const articlesValidation = ref({ valid: false, message: "請選擇路徑" })
 const blogValidation = ref<{ valid: boolean; warning?: boolean; message: string }>({ valid: false, message: "請選擇路徑" })
+const isSelectingPath = ref(false)
 
 const canSave = computed(() => {
   // 只需要文章資料夾即可儲存，部落格路徑為選填
@@ -700,6 +701,8 @@ const canSave = computed(() => {
 
 // Methods
 async function selectArticlesPath() {
+  if (isSelectingPath.value) {return}
+  isSelectingPath.value = true
   try {
     if (!globalThis.electronAPI) {
       logger.warn("瀏覽器模式下無法選擇資料夾")
@@ -720,10 +723,14 @@ async function selectArticlesPath() {
     }
   } catch (error) {
     logger.error("選擇資料夾失敗:", error)
+  } finally {
+    isSelectingPath.value = false
   }
 }
 
 async function selectBlogPath() {
+  if (isSelectingPath.value) {return}
+  isSelectingPath.value = true
   try {
     if (!globalThis.electronAPI) {
       logger.warn("瀏覽器模式下無法選擇資料夾")
@@ -732,18 +739,22 @@ async function selectBlogPath() {
 
     const selectedPath = await globalThis.electronAPI.selectDirectory({
       title: "選擇部落格專案資料夾",
-      defaultPath: localConfig.value.paths.targetBlog
+      defaultPath: localConfig.value.paths.targetDir
     })
 
     if (selectedPath) {
-      localConfig.value.paths.targetBlog = selectedPath
+      localConfig.value.paths.targetDir = selectedPath
     }
   } catch (error) {
     logger.error("選擇資料夾失敗:", error)
+  } finally {
+    isSelectingPath.value = false
   }
 }
 
 async function selectImagesPath() {
+  if (isSelectingPath.value) {return}
+  isSelectingPath.value = true
   try {
     if (!globalThis.electronAPI) {
       logger.warn("瀏覽器模式下無法選擇資料夾")
@@ -760,6 +771,8 @@ async function selectImagesPath() {
     }
   } catch (error) {
     logger.error("選擇資料夾失敗:", error)
+  } finally {
+    isSelectingPath.value = false
   }
 }
 
@@ -777,9 +790,9 @@ async function validatePaths() {
   }
 
   // Validate Blog Directory
-  if (localConfig.value.paths.targetBlog) {
+  if (localConfig.value.paths.targetDir) {
     try {
-      const result = await configStore.validateAstroBlog(localConfig.value.paths.targetBlog)
+      const result = await configStore.validateAstroBlog(localConfig.value.paths.targetDir)
       blogValidation.value = result
     } catch {
       blogValidation.value = { valid: false, message: "驗證失敗" }
@@ -808,7 +821,7 @@ function resetToDefaults() {
   localConfig.value = {
     paths: {
       articlesDir: "",
-      targetBlog: "",
+      targetDir: "",
       imagesDir: ""
     },
     editorConfig: {
@@ -826,7 +839,7 @@ function handleClose() {
 
 // Watch for path changes to trigger validation
 watch(
-  () => [localConfig.value.paths.articlesDir, localConfig.value.paths.targetBlog],
+  () => [localConfig.value.paths.articlesDir, localConfig.value.paths.targetDir],
   async () => {
     await validatePaths()
   }

--- a/src/main/services/ConfigService.ts
+++ b/src/main/services/ConfigService.ts
@@ -34,11 +34,22 @@ export class ConfigService {
   async getConfig(): Promise<AppConfig> {
     try {
       const configData = await fs.readFile(this.configPath, "utf-8")
-      return JSON.parse(configData)
+      const raw = JSON.parse(configData)
+      return this.migrate(raw)
     } catch {
       // Return default config if file doesn"t exist
       return this.getDefaultConfig()
     }
+  }
+
+  /** 處理舊版 config 欄位名稱（targetBlog → targetDir） */
+  private migrate(raw: Record<string, unknown>): AppConfig {
+    const paths = (raw.paths ?? {}) as Record<string, unknown>
+    if ("targetBlog" in paths && !("targetDir" in paths)) {
+      paths.targetDir = paths.targetBlog
+      delete paths.targetBlog
+    }
+    return raw as unknown as AppConfig
   }
 
   async setConfig(config: AppConfig): Promise<void> {


### PR DESCRIPTION
## 內容
- 補上 SettingsPanel.vue 缺少的 logger import（修正 #51 描述的 ReferenceError 問題）
- 選取資料夾按鈕加防重複點擊保護，dialog 開啟期間禁用按鈕
- 對齊前後端欄位名稱：targetBlog → targetDir
- ConfigService.migrate() 處理磁碟舊格式 config

## 關聯
Closes #51

## 來源
從長期停滯（落後 develop 22 commits）的 refactor/consolidate-autosave-timer 分支拆分重整而來。

## 驗證
- `pnpm run test`：683 passed
- `pnpm run lint`：0 errors