### PR TITLE
feat(ia): IA 稽核 Phase 2 第一項 — ServerControlPanel 掛載進編輯模式

### DIFF
--- a/docs/engineering/discussions/2026-08-04-ia-phase2-server-control-panel-integration.md
+++ b/docs/engineering/discussions/2026-08-04-ia-phase2-server-control-panel-integration.md
@@ -2,14 +2,15 @@
 title: "IA Phase 2 第一項：ServerControlPanel 掛載進編輯模式底部控制台"
 domain: engineering
 type: spec
-status: draft
+status: reviewing
 owner: tech-team
 updated: 2026-08-04
 source_of_truth: false
 tags:
   - ia-phase2
   - server-control-panel
-related_docs: []
+related_docs:
+  - docs/superpowers/plans/2026-08-04-ia-phase2-server-control-panel.md
 ---
 
 # IA Phase 2 第一項：ServerControlPanel 掛載進編輯模式底部控制台

--- a/docs/engineering/discussions/2026-08-04-ia-phase2-server-control-panel-integration.md
+++ b/docs/engineering/discussions/2026-08-04-ia-phase2-server-control-panel-integration.md
@@ -1,0 +1,99 @@
+---
+title: "IA Phase 2 第一項：ServerControlPanel 掛載進編輯模式底部控制台"
+domain: engineering
+type: spec
+status: draft
+owner: tech-team
+updated: 2026-08-04
+source_of_truth: false
+tags:
+  - ia-phase2
+  - server-control-panel
+related_docs: []
+---
+
+# IA Phase 2 第一項：ServerControlPanel 掛載進編輯模式底部控制台
+
+## 背景
+
+透過 `agy`（Antigravity CLI + Gemini 3.1 Pro）對 WriteFlow 編輯/撰寫畫面做的獨立 UIUX/IA 稽核，產出三階段改善路線圖（稽核報告本身未落檔，僅存在於 2026-08-02 的對話紀錄中）。Phase 1（5 項小修復）已完成並合併（`feat/ia-phase1-quick-wins`）。
+
+Phase 2 原定兩項「中度重構」：
+1. 整合發布/開發伺服器控制面板到編輯模式（本文件範圍）
+2. Frontmatter 編輯從遮罩 Modal 改成側邊欄內聯表單（另案處理，不在本文件範圍）
+
+兩項在 2026-08-02 的 brainstorming 中被中斷（未做出分開/合併的決定），本文件是 2026-08-04 接續討論後的結果，範圍已確認為**只做第一項**，且該項本身也在討論中被進一步縮小（見下）。
+
+## 現況調查
+
+- `ServerControlPanel.vue`（339 行）在 `src/` 中完全沒有任何 import／掛載，是徹底孤立元件。
+- 元件本身已是自足設計：控制列（狀態燈號、badge、伺服器 URL、清除日誌、展開/收合、啟動/停止）常駐顯示；日誌面板隨 `expanded` 收合；日誌高度已有 `resize-handle` 可拖曳調整（`logPanelHeight`）；未設定目標部落格時啟動按鈕會 disable，展開時顯示警告列。
+- **既有 bug**：`startServer()`/`stopServer()`/`updateStatus()` 呼叫 `logger.error(...)` 共 3 處，但檔案從未 `import { logger } from "@/utils/logger"`，掛載後首次觸發錯誤路徑會直接 runtime crash。其他元件（`ArticleTreeItem.vue`、`ConversionPanel.vue` 等）皆採 `import { logger } from "@/utils/logger"` 這個寫法。
+- 「一鍵同步本篇至 Blog」目前不存在：`PublishService` 只有 `syncAllPublished()`（全量同步，`ArticleManagement.vue` 管理模式在用），沒有單篇同步的 IPC channel。
+
+## 範圍決定
+
+經 brainstorming 澄清，本次範圍**縮小為只掛載現成元件**，理由與過程記錄如下：
+
+1. **版面位置**：底部控制台橫跨側邊欄＋編輯區全寬（而非只在編輯區下方）。理由：Dev Server 狀態是全域概念（不屬於單篇文章），橫跨全寬符合「工作區層級工具」的心智模型。
+2. **預設狀態**：進入編輯模式預設**收合**，只露出常駐控制列；需要看 log 才手動展開。
+3. **「同步本篇至 Blog」按鈕：不在本次範圍**，留待後續另案討論（涉及新 IPC channel、按鈕該掛在哪個元件等額外設計決策，与單純掛載既有元件性質不同）。
+4. **元件邊界**：既然不新增按鈕，不需要額外的包裝元件——直接在 `App.vue` 掛載 `ServerControlPanel`，不修改其對外介面。
+
+被否決的替代方案：
+- 新建 `EditorWorkspace.vue` 包裝 `SideBarView` + `MainEditor` + `ServerControlPanel`：在只掛載一個既有元件的前提下，多一層抽象不符合 YAGNI，等未來真的有第二個需要共用此容器的情境再抽。
+- 讓 `ServerControlPanel` 比照 `AIPanelView` 不分模式常駐：稽核報告與使用者決定都明確限定在「編輯模式」，管理模式沒有預覽/開發伺服器需求；`AIPanelView` 的「不分模式」是修正按鈕點擊無反應的 bug，非刻意設計原則，不適合套用在這裡。
+
+## 設計
+
+### 元件掛載
+
+`src/App.vue` 在 Editor Mode 區塊（`SideBarView` + `<main>` 的 flex row）之後，同一個 `Main Content Area` flex-col 內加入：
+
+```html
+<ServerControlPanel v-if="currentMode === ViewMode.Editor" />
+```
+
+不傳任何 props，`ServerControlPanel` 維持自足元件、自行管理 dev server 生命週期與日誌狀態。
+
+### 行為調整
+
+`src/components/ServerControlPanel.vue` 只改兩處既有預設值/import：
+
+- `import { logger } from "@/utils/logger"`（新增，修掉 3 處 `logger.error` runtime 錯誤）
+- `const expanded = ref(true)` → `const expanded = ref(false)`（掛載後預設收合）
+
+### 資料流
+
+沿用既有的 `configStore`（`hasTargetBlog` 判斷）與 `window.electronAPI.startDevServer/stopDevServer`，不新增 store 或 IPC channel。
+
+`ServerControlPanel` 掛載在 `App.vue` 層級（非 `MainEditor` 內部），切換文章不會重新掛載，伺服器運行狀態在切換文章間自然保留。**但切到管理模式時 `v-if` 會整個卸載元件**——代表切回管理模式再切回編輯模式時，日誌歷史會被清空、`isRunning` 需要重新查詢（`onMounted` 已有 `updateStatus()` 呼叫，可正確反映 main process 端的真實伺服器狀態，不會顯示錯誤的「已停止」）。此為已知且接受的行為，不在本次範圍內處理跨模式狀態保留（若日後需要，需挪去 Pinia store，屬於獨立的範圍擴張）。
+
+### 錯誤處理
+
+沿用元件既有邏輯，本次不新增錯誤處理路徑：
+- 未設定目標部落格：啟動按鈕 disable，展開時顯示警告列
+- 啟動/停止失敗：既有 try/catch 寫入 log（本次修復後才會真正被 `logger.error` 記錄而不崩潰）
+
+### 測試
+
+**Unit Test（新建 `tests/components/ServerControlPanel.test.ts`）**
+
+沿用 `tests/components/ArticleManagement.list.test.ts` 的 mock 慣例（`Object.defineProperty(window, "electronAPI", {...})` + `vi.fn()`），涵蓋：
+1. 掛載後 `expanded` 預設為 `false`（收合）
+2. mock `startDevServer` reject → 驗證 `logger.error` 被呼叫且錯誤訊息寫入 `logs`，不拋出未捕捉例外
+3. mock `stopDevServer` reject → 同上
+
+**E2E（`tests/e2e/`，併入既有 spec 或新建）**
+
+1. 編輯模式下底部控制台預設收合可見
+2. 點展開能看到日誌區
+3. 切到管理模式後控制台消失
+
+不在 E2E 中真的啟動 dev server（避免依賴真實 process 造成 flaky），啟停邏輯本身的正確性已由 unit test 覆蓋。
+
+## 範圍外（明確排除）
+
+- 「一鍵同步本篇至 Blog」按鈕與對應單篇同步 IPC channel
+- Phase 2 第二項：Frontmatter 側邊欄內聯編輯
+- 跨模式（管理模式 ↔ 編輯模式）保留伺服器狀態/日誌歷史

--- a/docs/superpowers/plans/2026-08-04-ia-phase2-server-control-panel.md
+++ b/docs/superpowers/plans/2026-08-04-ia-phase2-server-control-panel.md
@@ -13,11 +13,11 @@
 - Modify: `src/components/ServerControlPanel.vue`
 - Test: `tests/components/ServerControlPanel.test.ts`（create）
 
-- [ ] Step 1：建立 `tests/components/ServerControlPanel.test.ts`，沿用 `tests/components/ArticleManagement.list.test.ts` 的 `Object.defineProperty(window, "electronAPI", {...})` mock 慣例，撰寫 3 個案例：(a) mount 後 `expanded` 為 `false`（可從 log 面板 DOM 是否存在間接驗證，不直接讀 component internal state）(b) mock `startDevServer` reject → 觸發 `startServer()` 後不拋出未捕捉例外，且 log 容器出現錯誤訊息 (c) mock `stopDevServer` reject → 同上
-- [ ] Step 2：執行測試確認失敗 — `npx vitest run tests/components/ServerControlPanel.test.ts`，Expected: FAIL（`expanded` 目前預設 `true`；`logger` 未 import 會讓 (b)(c) 直接拋出 ReferenceError）
-- [ ] Step 3：修正 `ServerControlPanel.vue`：新增 `import { logger } from "@/utils/logger"`；`const expanded = ref(true)` 改為 `const expanded = ref(false)`
-- [ ] Step 4：執行測試確認通過 — `npx vitest run tests/components/ServerControlPanel.test.ts`，Expected: PASS（3 tests）
-- [ ] Step 5：Commit — `git commit -m "fix(server-control-panel): 補上 logger import 並修正預設收合狀態"`
+- [x] Step 1：建立 `tests/components/ServerControlPanel.test.ts`，沿用 `tests/components/ArticleManagement.list.test.ts` 的 `Object.defineProperty(window, "electronAPI", {...})` mock 慣例，撰寫 3 個案例：(a) mount 後 `expanded` 為 `false`（可從 log 面板 DOM 是否存在間接驗證，不直接讀 component internal state）(b) mock `startDevServer` reject → 觸發 `startServer()` 後不拋出未捕捉例外，且 log 容器出現錯誤訊息 (c) mock `stopDevServer` reject → 同上
+- [x] Step 2：執行測試確認失敗 — `npx vitest run tests/components/ServerControlPanel.test.ts`，Expected: FAIL（`expanded` 目前預設 `true`；`logger` 未 import 會讓 (b)(c) 直接拋出 ReferenceError）。實測：3 個案例皆如預期失敗；(c) 案例最初因缺少斷言而誤判通過，補上 `process.on("unhandledRejection", ...)` 追蹤後才驗證出真正的 RED
+- [x] Step 3：修正 `ServerControlPanel.vue`：新增 `import { logger } from "@/utils/logger"`；`const expanded = ref(true)` 改為 `const expanded = ref(false)`
+- [x] Step 4：執行測試確認通過 — `npx vitest run tests/components/ServerControlPanel.test.ts`，Expected: PASS（3 tests）。實測：PASS (3)
+- [x] Step 5：Commit — `git commit -m "fix(server-control-panel): 補上 logger import 並修正預設收合狀態"`
 
 ### Task 2：App.vue 掛載與 E2E 驗證
 
@@ -25,18 +25,18 @@
 - Modify: `src/App.vue`
 - Test: `tests/e2e/server-control-panel.spec.ts`（create）
 
-- [ ] Step 1：建立 `tests/e2e/server-control-panel.spec.ts`，撰寫 3 個案例：(a) 進入編輯模式後底部控制台的常駐控制列可見，且日誌面板預設不可見（收合） (b) 點擊展開按鈕後日誌面板可見 (c) 切換到管理模式後底部控制台整個消失
-- [ ] Step 2：執行單一測試確認失敗 — `npx playwright test tests/e2e/server-control-panel.spec.ts`，Expected: FAIL（`ServerControlPanel` 尚未掛載，對應 DOM 選取不到）
-- [ ] Step 3：修改 `App.vue`：在 Editor Mode 區塊（`SideBarView` + `<main>` 的 flex row）之後、同一個 Main Content Area flex-col 內，加入 `<ServerControlPanel v-if="currentMode === ViewMode.Editor" />`；補上對應 import
-- [ ] Step 4：執行測試確認通過 — `npx playwright test tests/e2e/server-control-panel.spec.ts`，Expected: PASS（3 tests）
-- [ ] Step 5：Commit — `git commit -m "feat(editor): 將 ServerControlPanel 掛載進編輯模式底部控制台"`
+- [x] Step 1：建立 `tests/e2e/server-control-panel.spec.ts`，撰寫 3 個案例：(a) 進入編輯模式後底部控制台的常駐控制列可見，且日誌面板預設不可見（收合） (b) 點擊展開按鈕後日誌面板可見 (c) 切換到管理模式後底部控制台整個消失。實作時另補上 `data-testid`（server-control-panel / server-panel-toggle / server-panel-log）供穩定選取
+- [x] Step 2：執行單一測試確認失敗 — `npx playwright test tests/e2e/server-control-panel.spec.ts`，Expected: FAIL（`ServerControlPanel` 尚未掛載，對應 DOM 選取不到）。實測：3 個案例皆如預期失敗
+- [x] Step 3：修改 `App.vue`：在 Editor Mode 區塊（`SideBarView` + `<main>` 的 flex row）之後、同一個 Main Content Area flex-col 內，加入 `<ServerControlPanel v-if="currentMode === ViewMode.Editor" />`；補上對應 import
+- [x] Step 4：執行測試確認通過 — `npx playwright test tests/e2e/server-control-panel.spec.ts`，Expected: PASS（3 tests）。實測：PASS (3)
+- [x] Step 5：Commit — `git commit -m "feat(editor): 將 ServerControlPanel 掛載進編輯模式底部控制台"`
 
 ### Task 3：全量驗證
 
 **Files:**
 - （無新增/修改檔案，純驗證）
 
-- [ ] Step 1：執行完整單元測試 — `pnpm run test`，Expected: PASS（0 failures）
-- [ ] Step 2：執行完整 E2E 套件 — `pnpm run test:e2e`，Expected: PASS（0 failures），依 `e2e-testing-rules` skill 若失敗先讀 `test-results/renderer-console.log` 排查，不盲跑猜測
-- [ ] Step 3：執行 Lint — `pnpm run lint`，Expected: 0 errors
-- [ ] Step 4：確認範圍外項目未被誤動——`git diff develop..HEAD --stat` 只包含 `ServerControlPanel.vue`、`App.vue`、兩支測試檔與 spec/plan 文件
+- [x] Step 1：執行完整單元測試 — `pnpm run test`，Expected: PASS（0 failures）。實測：687 passed | 1 skipped（既有跳過案例，與本次無關）
+- [x] Step 2：執行完整 E2E 套件 — `pnpm run test:e2e`，Expected: PASS（0 failures）。實測：31 passed | 1 skipped（既有跳過案例，與本次無關）
+- [x] Step 3：執行 Lint — `pnpm run lint`，Expected: 0 errors。實測：0 errors, 23 warnings（皆為既有檔案的既存警告，非本次改動）
+- [x] Step 4：確認範圍外項目未被誤動——`git diff develop..HEAD --stat` 只包含 `ServerControlPanel.vue`、`App.vue`、兩支測試檔與 spec/plan 文件。實測：6 files changed，完全符合預期範圍

--- a/docs/superpowers/plans/2026-08-04-ia-phase2-server-control-panel.md
+++ b/docs/superpowers/plans/2026-08-04-ia-phase2-server-control-panel.md
@@ -1,0 +1,42 @@
+# IA Phase 2 第一項：ServerControlPanel 掛載 實作計畫
+
+**Goal:** 把目前完全孤立的 `ServerControlPanel.vue` 掛載進編輯模式，成為橫跨側邊欄＋編輯區、預設收合的底部控制台，並修掉其既有的 logger 未 import 的 runtime bug。
+**Architecture:** 不新增 store/IPC/包裝元件；直接在 `App.vue` 的 Editor Mode 區塊加一行 `v-if` 掛載，`ServerControlPanel.vue` 本身只改兩個既有預設值。
+**Tech Stack:** Vue 3 `<script setup>`、Vitest + `@vue/test-utils`（unit）、Playwright（e2e）
+**Spec:** `docs/engineering/discussions/2026-08-04-ia-phase2-server-control-panel-integration.md`
+
+---
+
+### Task 1：ServerControlPanel 元件修正
+
+**Files:**
+- Modify: `src/components/ServerControlPanel.vue`
+- Test: `tests/components/ServerControlPanel.test.ts`（create）
+
+- [ ] Step 1：建立 `tests/components/ServerControlPanel.test.ts`，沿用 `tests/components/ArticleManagement.list.test.ts` 的 `Object.defineProperty(window, "electronAPI", {...})` mock 慣例，撰寫 3 個案例：(a) mount 後 `expanded` 為 `false`（可從 log 面板 DOM 是否存在間接驗證，不直接讀 component internal state）(b) mock `startDevServer` reject → 觸發 `startServer()` 後不拋出未捕捉例外，且 log 容器出現錯誤訊息 (c) mock `stopDevServer` reject → 同上
+- [ ] Step 2：執行測試確認失敗 — `npx vitest run tests/components/ServerControlPanel.test.ts`，Expected: FAIL（`expanded` 目前預設 `true`；`logger` 未 import 會讓 (b)(c) 直接拋出 ReferenceError）
+- [ ] Step 3：修正 `ServerControlPanel.vue`：新增 `import { logger } from "@/utils/logger"`；`const expanded = ref(true)` 改為 `const expanded = ref(false)`
+- [ ] Step 4：執行測試確認通過 — `npx vitest run tests/components/ServerControlPanel.test.ts`，Expected: PASS（3 tests）
+- [ ] Step 5：Commit — `git commit -m "fix(server-control-panel): 補上 logger import 並修正預設收合狀態"`
+
+### Task 2：App.vue 掛載與 E2E 驗證
+
+**Files:**
+- Modify: `src/App.vue`
+- Test: `tests/e2e/server-control-panel.spec.ts`（create）
+
+- [ ] Step 1：建立 `tests/e2e/server-control-panel.spec.ts`，撰寫 3 個案例：(a) 進入編輯模式後底部控制台的常駐控制列可見，且日誌面板預設不可見（收合） (b) 點擊展開按鈕後日誌面板可見 (c) 切換到管理模式後底部控制台整個消失
+- [ ] Step 2：執行單一測試確認失敗 — `npx playwright test tests/e2e/server-control-panel.spec.ts`，Expected: FAIL（`ServerControlPanel` 尚未掛載，對應 DOM 選取不到）
+- [ ] Step 3：修改 `App.vue`：在 Editor Mode 區塊（`SideBarView` + `<main>` 的 flex row）之後、同一個 Main Content Area flex-col 內，加入 `<ServerControlPanel v-if="currentMode === ViewMode.Editor" />`；補上對應 import
+- [ ] Step 4：執行測試確認通過 — `npx playwright test tests/e2e/server-control-panel.spec.ts`，Expected: PASS（3 tests）
+- [ ] Step 5：Commit — `git commit -m "feat(editor): 將 ServerControlPanel 掛載進編輯模式底部控制台"`
+
+### Task 3：全量驗證
+
+**Files:**
+- （無新增/修改檔案，純驗證）
+
+- [ ] Step 1：執行完整單元測試 — `pnpm run test`，Expected: PASS（0 failures）
+- [ ] Step 2：執行完整 E2E 套件 — `pnpm run test:e2e`，Expected: PASS（0 failures），依 `e2e-testing-rules` skill 若失敗先讀 `test-results/renderer-console.log` 排查，不盲跑猜測
+- [ ] Step 3：執行 Lint — `pnpm run lint`，Expected: 0 errors
+- [ ] Step 4：確認範圍外項目未被誤動——`git diff develop..HEAD --stat` 只包含 `ServerControlPanel.vue`、`App.vue`、兩支測試檔與 spec/plan 文件

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,9 @@
       <template v-else-if="currentMode === ViewMode.Management">
         <ArticleManagement @edit-article="switchToEditorMode" />
       </template>
+
+      <!-- 開發伺服器底部控制台（IA 稽核 Phase 2 第一項）：橫跨側邊欄＋編輯區，只在編輯模式顯示 -->
+      <ServerControlPanel v-if="currentMode === ViewMode.Editor" />
     </div>
 
     <!-- AI 助手面板：右側可收合 dock，任何模式都能開關（ActivityBar 按鈕不分模式都可點，
@@ -100,6 +103,7 @@ import SearchPanel from "@/components/SearchPanel.vue";
 import ToastContainer from "@/components/ToastContainer.vue";
 import ArticleManagement from "@/components/ArticleManagement.vue";
 import AIPanelView from "@/components/AIPanelView.vue";
+import ServerControlPanel from "@/components/ServerControlPanel.vue";
 
 const configStore = useConfigStore();
 const articleStore = useArticleStore();

--- a/src/components/ServerControlPanel.vue
+++ b/src/components/ServerControlPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="server-control-panel">
+  <div class="server-control-panel" data-testid="server-control-panel">
     <!-- 控制列 -->
     <div class="flex items-center justify-between p-3 bg-base-200 border-b border-base-300">
       <div class="flex items-center gap-3">
@@ -42,6 +42,7 @@
         <!-- 折疊/展開按鈕 -->
         <button
           class="btn btn-ghost btn-sm"
+          data-testid="server-panel-toggle"
           @click="toggleExpanded"
           :title="expanded ? '收合' : '展開'"
         >
@@ -74,6 +75,7 @@
     <div
       v-if="expanded"
       class="log-panel bg-base-300 overflow-hidden"
+      data-testid="server-panel-log"
       :style="{ height: logPanelHeight + 'px' }"
     >
       <!-- 日誌內容 -->

--- a/src/components/ServerControlPanel.vue
+++ b/src/components/ServerControlPanel.vue
@@ -114,6 +114,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from "vue"
 import { useConfigStore } from "@/stores/config"
+import { logger } from "@/utils/logger"
 import {
   Play,
   Square,
@@ -132,7 +133,7 @@ const isRunning = ref(false)
 const loading = ref(false)
 const serverUrl = ref<string | undefined>()
 const logs = ref<ServerLogData[]>([])
-const expanded = ref(true)
+const expanded = ref(false)
 const logPanelHeight = ref(200)
 const logContainerRef = ref<HTMLElement>()
 

--- a/tests/components/ServerControlPanel.test.ts
+++ b/tests/components/ServerControlPanel.test.ts
@@ -1,0 +1,104 @@
+/**
+ * ServerControlPanel — 掛載進編輯模式前的兩個既有缺陷
+ * 1. `expanded` 預設值需為 false（掛載進編輯模式時預設收合）
+ * 2. startServer/stopServer 失敗時呼叫 logger.error，但檔案從未 import logger，
+ *    掛載後首次觸發錯誤路徑會直接 runtime crash（ReferenceError: logger is not defined）
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { mount, flushPromises, type VueWrapper } from "@vue/test-utils"
+import { setActivePinia, createPinia } from "pinia"
+import { useConfigStore } from "@/stores/config"
+import ServerControlPanel from "@/components/ServerControlPanel.vue"
+
+function setupElectronAPI(overrides: Record<string, unknown> = {}) {
+  Object.defineProperty(window, "electronAPI", {
+    value: {
+      getServerStatus: vi.fn().mockResolvedValue({ running: false, url: undefined }),
+      startDevServer: vi.fn().mockResolvedValue(undefined),
+      stopDevServer: vi.fn().mockResolvedValue(undefined),
+      onServerLog: vi.fn(() => vi.fn()),
+      ...overrides,
+    },
+    writable: true,
+    configurable: true,
+  })
+}
+
+function findButtonByText(wrapper: VueWrapper, text: string) {
+  const btn = wrapper.findAll("button").find((b) => b.text().includes(text))
+  if (!btn) {throw new Error(`Button with text "${text}" not found`)}
+  return btn
+}
+
+describe("ServerControlPanel - 預設收合狀態", () => {
+  let wrapper: VueWrapper | undefined
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    setupElectronAPI()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+  })
+
+  it("首次掛載時日誌面板應為收合狀態（不可見）", async () => {
+    wrapper = mount(ServerControlPanel)
+    await flushPromises()
+    expect(wrapper.find(".log-panel").exists()).toBe(false)
+  })
+})
+
+describe("ServerControlPanel - logger 未 import 的 bug 修復", () => {
+  let wrapper: VueWrapper | undefined
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    const configStore = useConfigStore()
+    configStore.config.paths.targetDir = "/blog/target"
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+  })
+
+  it("啟動伺服器失敗時應把錯誤訊息寫入日誌（若 logger 未 import 會在寫入前就拋出）", async () => {
+    setupElectronAPI({ startDevServer: vi.fn().mockRejectedValue(new Error("啟動失敗")) })
+    wrapper = mount(ServerControlPanel, { attachTo: document.body })
+    await flushPromises()
+
+    // 日誌預設收合，先展開才看得到錯誤訊息
+    await wrapper.find('button[title="展開"]').trigger("click")
+    await findButtonByText(wrapper, "啟動").trigger("click")
+    await flushPromises()
+
+    expect(wrapper.text()).toContain("啟動失敗")
+  })
+
+  it("停止伺服器失敗時點擊不應觸發未捕捉的 Promise rejection", async () => {
+    setupElectronAPI({
+      getServerStatus: vi.fn().mockResolvedValue({ running: true, url: "http://localhost:4321" }),
+      stopDevServer: vi.fn().mockRejectedValue(new Error("停止失敗")),
+    })
+    wrapper = mount(ServerControlPanel, { attachTo: document.body })
+    await flushPromises()
+
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on("unhandledRejection", onRejection)
+
+    try {
+      await findButtonByText(wrapper, "停止").trigger("click")
+      await flushPromises()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    } finally {
+      process.off("unhandledRejection", onRejection)
+    }
+
+    expect(rejections).toEqual([])
+  })
+})

--- a/tests/components/ServerControlPanel.test.ts
+++ b/tests/components/ServerControlPanel.test.ts
@@ -1,7 +1,7 @@
 /**
  * ServerControlPanel — 掛載進編輯模式前的兩個既有缺陷
  * 1. `expanded` 預設值需為 false（掛載進編輯模式時預設收合）
- * 2. startServer/stopServer 失敗時呼叫 logger.error，但檔案從未 import logger，
+ * 2. startServer/stopServer/updateStatus 失敗時呼叫 logger.error，但檔案從未 import logger，
  *    掛載後首次觸發錯誤路徑會直接 runtime crash（ReferenceError: logger is not defined）
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
@@ -93,6 +93,24 @@ describe("ServerControlPanel - logger 未 import 的 bug 修復", () => {
 
     try {
       await findButtonByText(wrapper, "停止").trigger("click")
+      await flushPromises()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    } finally {
+      process.off("unhandledRejection", onRejection)
+    }
+
+    expect(rejections).toEqual([])
+  })
+
+  it("初始載入伺服器狀態失敗時不應觸發未捕捉的 Promise rejection", async () => {
+    setupElectronAPI({ getServerStatus: vi.fn().mockRejectedValue(new Error("取得狀態失敗")) })
+
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on("unhandledRejection", onRejection)
+
+    try {
+      wrapper = mount(ServerControlPanel, { attachTo: document.body })
       await flushPromises()
       await new Promise((resolve) => setTimeout(resolve, 0))
     } finally {

--- a/tests/e2e/server-control-panel.spec.ts
+++ b/tests/e2e/server-control-panel.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * 底部開發伺服器控制台 E2E 測試（IA 稽核 Phase 2 第一項）
+ *
+ * 背景：ServerControlPanel.vue 原本完全沒有掛載進 App.vue，是徹底孤立元件。
+ * 這裡驗證它已掛載進編輯模式、預設收合，且只在編輯模式顯示。
+ *
+ * 選擇器策略：data-testid 優先（E2E 穩定性最高）
+ */
+
+import { test, expect } from "./helpers/electron-fixture";
+
+test.describe("底部開發伺服器控制台", () => {
+  test("編輯模式下預設可見且收合，日誌面板不可見", async ({ window }) => {
+    const panel = window.getByTestId("server-control-panel");
+    const log = window.getByTestId("server-panel-log");
+
+    await expect(panel).toBeVisible();
+    await expect(log).not.toBeVisible();
+  });
+
+  test("點擊展開按鈕能看到日誌面板，再點一次收合", async ({ window }) => {
+    const toggle = window.getByTestId("server-panel-toggle");
+    const log = window.getByTestId("server-panel-log");
+
+    await toggle.click();
+    await expect(log).toBeVisible();
+
+    // 還原收合狀態，避免影響共用 worker 內的其他測試
+    await toggle.click();
+    await expect(log).not.toBeVisible();
+  });
+
+  test("切換到管理模式後控制台消失，切回編輯模式後再次出現", async ({ window }) => {
+    const panel = window.getByTestId("server-control-panel");
+
+    await window.locator('button[title^="管理模式"]').click();
+    await expect(panel).not.toBeVisible();
+
+    // 還原模式，避免影響共用 worker 內的其他測試
+    await window.locator('button[title^="編輯模式"]').click();
+    await expect(panel).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 背景

延續 IA 稽核 Phase 1（`feat/ia-phase1-quick-wins`），Phase 2 原定兩項「中度重構」中的第一項。經 brainstorming 確認範圍縮小為：只把現成的 `ServerControlPanel.vue` 掛載進編輯模式，不新增「同步本篇至 Blog」按鈕（留待後續另案處理）。

## 變更內容

- `ServerControlPanel.vue` 在 `src/` 中原本完全沒有任何 import/掛載，是徹底孤立元件，且有 `logger` 未 import 的既有 bug（`startServer`/`stopServer`/`updateStatus` 失敗時會直接 ReferenceError 崩潰）
- 修正該 bug，並將 `expanded` 預設值改為 `false`（掛載進編輯模式後預設收合）
- 在 `App.vue` 的 Editor Mode 區塊掛載 `ServerControlPanel`，橫跨側邊欄＋編輯區全寬，只在編輯模式顯示
- 補上 `data-testid` 供 E2E 穩定選取

## 文件

- Spec：`docs/engineering/discussions/2026-08-04-ia-phase2-server-control-panel-integration.md`（status: reviewing）
- Plan：`docs/superpowers/plans/2026-08-04-ia-phase2-server-control-panel.md`

## Code Review 後續修正

- 補上 `updateStatus()` 失敗路徑的 unit test（原本 3 處 `logger.error` 呼叫點只測了 2 處，遺漏 onMounted 初始載入狀態這條路徑）
- spec 狀態從 `draft` 推進為 `reviewing` 並補上 `related_docs`

## Test plan

- [x] `pnpm run test` — 全數通過
- [x] `pnpm run test:e2e` — 全數通過，`tests/e2e/server-control-panel.spec.ts` 3 案例全通過
- [x] `pnpm run lint` — 0 errors
- [x] `tests/components/ServerControlPanel.test.ts` 4 案例：預設收合狀態、startServer/stopServer/updateStatus 三處失敗路徑皆驗證錯誤訊息實際顯示或不觸發未捕捉 Promise rejection（TDD red-green 皆已驗證）